### PR TITLE
Exclude empty lists from to_dict output

### DIFF
--- a/betterproto/__init__.py
+++ b/betterproto/__init__.py
@@ -728,7 +728,8 @@ class Message(ABC):
                 elif isinstance(v, list):
                     # Convert each item.
                     v = [i.to_dict(casing) for i in v]
-                    output[cased_name] = v
+                    if v:
+                        output[cased_name] = v
                 elif v._serialized_on_wire:
                     output[cased_name] = v.to_dict(casing)
             elif meta.proto_type == "map":

--- a/betterproto/__init__.py
+++ b/betterproto/__init__.py
@@ -733,7 +733,7 @@ class Message(ABC):
                 elif isinstance(v, list):
                     # Convert each item.
                     v = [i.to_dict(casing, include_default_values) for i in v]
-                    if v:
+                    if v or include_default_values:
                         output[cased_name] = v
                 else:
                     if v._serialized_on_wire or include_default_values:


### PR DESCRIPTION
I've found to_dict output to be very verbose and in particular filled with empty lists.

Not quite sure if this PR is 100% okay with the author - if it would be better gated behind some argument passed into to_dict then I'm okay to make the necessary changes.

As far as I know, I've never seen a required list field in a protocol buffer, which is why I have proposed the change in its current state