### PR TITLE
#27 Make _get_field_default support py3.6 values of __origin__

### DIFF
--- a/betterproto/__init__.py
+++ b/betterproto/__init__.py
@@ -569,10 +569,10 @@ class Message(ABC):
 
         value: Any = 0
         if hasattr(t, "__origin__"):
-            if t.__origin__ == dict:
+            if t.__origin__ in (dict, Dict):
                 # This is some kind of map (dict in Python).
                 value = {}
-            elif t.__origin__ == list:
+            elif t.__origin__ in (list, List):
                 # This is some kind of list (repeated) field.
                 value = []
             elif t.__origin__ == Union and t.__args__[1] == type(None):


### PR DESCRIPTION
From my limited testing I believe this is a sufficient change (along with updating the python version in pyproject.toml and setup.py) to support python 3.6.8.