### PR TITLE
Fixes issue where protoc did not recognize plugin.py as win32 application

### DIFF
--- a/betterproto/plugin.bat
+++ b/betterproto/plugin.bat
@@ -1,0 +1,1 @@
+@python ../plugin.py %*

--- a/betterproto/plugin.bat
+++ b/betterproto/plugin.bat
@@ -1,1 +1,2 @@
-@python ../plugin.py %*
+@SET plugin_dir=%~dp0
+@python %plugin_dir%/plugin.py %*

--- a/betterproto/tests/generate.py
+++ b/betterproto/tests/generate.py
@@ -48,13 +48,19 @@ if __name__ == "__main__":
         proto_files = get_files(".proto")
         json_files = get_files(".json")
 
+    if os.name == 'nt':
+        plugin_path = os.path.join('..', 'plugin.bat')
+    else:
+        plugin_path = os.path.join('..', 'plugin.py')
+    
+
     for filename in proto_files:
         print(f"Generating code for {os.path.basename(filename)}")
         subprocess.run(
             f"protoc --python_out=. {os.path.basename(filename)}", shell=True
         )
         subprocess.run(
-            f"protoc --plugin=protoc-gen-custom=../plugin.py --custom_out=. {os.path.basename(filename)}",
+            f"protoc --plugin=protoc-gen-custom={plugin_path} --custom_out=. {os.path.basename(filename)}",
             shell=True,
         )
 


### PR DESCRIPTION
Hi~

Thanks for this awesome library!

There's a bug however that I want to look into, but I couldn't run `generate` on my windows system. This PR fixes that.

When running `pyenv run generate` on windows, `protoc` does not accept `../plugin.py` as an executable win32 application.

See for example: https://github.com/protocolbuffers/protobuf/issues/3923

This PR adds a `.bat` file that executes python, which is used when running the `generate.py` on windows.