### PR TITLE
Fixes input messages from other packages being skipped

### DIFF
--- a/betterproto/plugin.py
+++ b/betterproto/plugin.py
@@ -357,11 +357,8 @@ def generate_code(request, response):
                         raise NotImplementedError("Client streaming not yet supported")
 
                     input_message = None
-                    input_type = get_ref_type(
-                        package, output["imports"], method.input_type
-                    ).strip('"')
                     for msg in output["messages"]:
-                        if msg["name"] == input_type:
+                        if msg["name"] == method.input_type:
                             input_message = msg
                             for field in msg["properties"]:
                                 if field["zero"] == "None":


### PR DESCRIPTION
In the following example, the input message `GetLayersRequest` would not be included in the generated Python client.

```protobuf

package anagon.ai.go;

import "training.proto";

service Go {
    rpc GetLayers (training.GetLayersRequest) returns (training.LayersResponse);
}
```

```protobuf

package anagon.ai.go.training;

message GetLayersRequest {
    int32 id = 1;
}
```


Client:

```python
    ...
    async def get_layers(self) -> training.LayersResponse:
        request = training.GetLayersRequest()

        return await self._unary_unary(
            "/anagon.ai.go.Go/GetLayers", request, training.LayersResponse,
        )
```

-  You can see that `get_layers()` is missing the `id=` parameter.

This pr fixes that.


I took extracted this fix from a bigger PR I'm working on that fixes a lot of issues, and I'm not sure if these kinds of imports will fully work without other fixes. I'm having difficulty testing PR's based off of master, because #38 is not merged yet.

Thanks for having a look!