### PR TITLE
Adding basic support (untested) for client streaming

### DIFF
--- a/betterproto/__init__.py
+++ b/betterproto/__init__.py
@@ -14,7 +14,8 @@ from typing import (
     Dict,
     Generator,
     Iterable,
-    Iterator, List,
+    Iterator,
+    List,
     Optional,
     SupportsBytes,
     Tuple,
@@ -1033,7 +1034,11 @@ class ServiceStub(ABC):
                 yield message
 
     async def _stream_unary(
-        self, route: str, request_iterator: Iterator["IProtoMessage"], request_type: Type[ST], response_type: Type[T]
+        self,
+        route: str,
+        request_iterator: Iterator["IProtoMessage"],
+        request_type: Type[ST],
+        response_type: Type[T],
     ) -> T:
         """Make a unary request and return the stream response iterator."""
         async with self.channel.request(
@@ -1047,7 +1052,11 @@ class ServiceStub(ABC):
             return response
 
     async def _stream_stream(
-        self, route: str, request_iterator: Iterator["IProtoMessage"], request_type: Type[ST], response_type: Type[T]
+        self,
+        route: str,
+        request_iterator: Iterator["IProtoMessage"],
+        request_type: Type[ST],
+        response_type: Type[T],
     ) -> AsyncGenerator[T, None]:
         """Make a unary request and return the stream response iterator."""
         async with self.channel.request(

--- a/betterproto/__init__.py
+++ b/betterproto/__init__.py
@@ -16,7 +16,7 @@ from typing import (
     Iterable,
     Iterator, List,
     Optional,
-    Sequence, SupportsBytes,
+    SupportsBytes,
     Tuple,
     Type,
     TypeVar,

--- a/betterproto/__init__.py
+++ b/betterproto/__init__.py
@@ -1040,7 +1040,7 @@ class ServiceStub(ABC):
         request_type: Type[ST],
         response_type: Type[T],
     ) -> T:
-        """Make a unary request and return the stream response iterator."""
+        """Make a stream request and return the response."""
         async with self.channel.request(
             route, grpclib.const.Cardinality.STREAM_UNARY, request_type, response_type
         ) as stream:
@@ -1058,7 +1058,7 @@ class ServiceStub(ABC):
         request_type: Type[ST],
         response_type: Type[T],
     ) -> AsyncGenerator[T, None]:
-        """Make a unary request and return the stream response iterator."""
+        """Make a stream request and return the stream response iterator."""
         async with self.channel.request(
             route, grpclib.const.Cardinality.STREAM_STREAM, request_type, response_type
         ) as stream:

--- a/betterproto/plugin.py
+++ b/betterproto/plugin.py
@@ -353,8 +353,6 @@ def generate_code(request, response):
                 }
 
                 for j, method in enumerate(service.method):
-                    if method.client_streaming:
-                        raise NotImplementedError("Client streaming not yet supported")
 
                     input_message = None
                     input_type = get_ref_type(
@@ -388,6 +386,9 @@ def generate_code(request, response):
 
                     if method.server_streaming:
                         output["typing_imports"].add("AsyncGenerator")
+
+                    if method.client_streaming:
+                        output["typing_imports"].add("Iterator")
 
                 output["services"].append(data)
 

--- a/betterproto/templates/template.py
+++ b/betterproto/templates/template.py
@@ -97,7 +97,7 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
         {% endif %}
 
         {% if method.server_streaming %}
-            {% if method.client_streaming %}
+        {% if method.client_streaming %}
         async for response in self._stream_stream(
             "{{ method.route }}",
             request_iterator,
@@ -105,7 +105,7 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
             {{ method.output }},
         ):
             yield response
-            {% else %}
+        {% else %}{# i.e. not client streaming #}
         async for response in self._unary_stream(
             "{{ method.route }}",
             request,
@@ -113,8 +113,8 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
         ):
             yield response
 
-            {% endif %}
-        {% else %}
+        {% endif %}{# if client streaming #}
+        {% else %}{# i.e. not server streaming #}
         {% if method.client_streaming %}
         return await self._stream_unary(
             "{{ method.route }}",
@@ -122,13 +122,13 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
             {{ method.input }},
             {{ method.output }}
         )
-        {% else %}
+        {% else %}{# i.e. not client streaming #}
         return await self._unary_unary(
             "{{ method.route }}",
             request,
             {{ method.output }}
         )
-        {% endif %}
+        {% endif %}{# client streaming #}
         {% endif %}
 
     {% endfor %}


### PR DESCRIPTION
I haven't written tests for this, but added the base methods for `stream_unary` and `stream_stream` support.  I realize this presents a bit of a challenge when it comes to API consistency since the attrs of the request can't be exploded out into kwargs like the `unary_unary` and `unary_stream` methods.  I went the simple route and just added `request_iterator` param to these methods.

Let me know if changes needed, etc.