### PR TITLE
[Draft] Fix many import related bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[unreleased]: https://github.com/danielgtaylor/python-betterproto/compare/v1.2.2...HEAD
+[unreleased]: https://github.com/danielgtaylor/python-betterproto/compare/v1.2.3...HEAD
+[1.2.3]: https://github.com/danielgtaylor/python-betterproto/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/danielgtaylor/python-betterproto/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/danielgtaylor/python-betterproto/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/danielgtaylor/python-betterproto/compare/v1.1.0...v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.3] - 2020-04-15
 
 - Exclude empty lists from `to_dict` by default [#16](https://github.com/danielgtaylor/python-betterproto/pull/16)
 - Add `include_default_values` parameter for `to_dict` [#12](https://github.com/danielgtaylor/python-betterproto/pull/12)
+- Fix class names being prepended with duplicates when using protocol buffers that are nested more than once [#21](https://github.com/danielgtaylor/python-betterproto/pull/21)
+- Add support for python 3.6 [#30](https://github.com/danielgtaylor/python-betterproto/pull/30)
 
 ## [1.2.2] - 2020-01-09
 

--- a/betterproto/plugin.bat
+++ b/betterproto/plugin.bat
@@ -1,0 +1,1 @@
+@python ../plugin.py %*

--- a/betterproto/plugin.bat
+++ b/betterproto/plugin.bat
@@ -1,1 +1,2 @@
-@python ../plugin.py %*
+@SET plugin_dir=%~dp0
+@python %plugin_dir%/plugin.py %*

--- a/betterproto/plugin.py
+++ b/betterproto/plugin.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+import collections
 import itertools
 import json
 import os.path
@@ -31,7 +31,6 @@ from google.protobuf.descriptor_pb2 import (
 from betterproto.casing import safe_snake_case
 
 import google.protobuf.wrappers_pb2
-
 
 WRAPPER_TYPES = {
     google.protobuf.wrappers_pb2.DoubleValue: "float",
@@ -91,10 +90,32 @@ def get_ref_type(package: str, imports: set, type_name: str, unwrap: bool = True
     if "." in type_name:
         # This is imported from another package. No need
         # to use a forward ref and we need to add the import.
-        parts = type_name.split(".")
-        parts[-1] = stringcase.pascalcase(parts[-1])
-        imports.add(f"from .{'.'.join(parts[:-2])} import {parts[-2]}")
-        type_name = f"{parts[-2]}.{parts[-1]}"
+        type_package, type_base_name = type_name.rsplit('.', 1)
+
+        import_child_package = type_package.startswith(package + '.')
+        import_parent_package = package.startswith(type_package + '.')
+
+        if import_child_package:
+            relative_package = type_package[len(package) + 1:]
+            relative_type_name = relative_package + '.' + type_base_name
+
+            imports.add(f"from . import {relative_package} # relative import from {package}")
+            return relative_type_name
+        elif import_parent_package:
+            imports.add(f"import {type_package} # absolute parent import from {package}")
+            return f"'{type_package}.{type_base_name}'"
+        elif not package:
+            if type_package.count('.'):
+                type_packages = type_package.rsplit('.', 1)
+                sys.stderr.write(f"type_package = {type_packages}\n")
+                alias = safe_snake_case(type_package)
+                imports.add(f"from .{type_packages[0]} import {type_packages[1]} as {alias} # relative import from root")
+                return f"'{alias}.{type_base_name}'"
+            else:
+                imports.add(f"from . import {type_package} # import child from root")
+            return type_name
+
+        return type_name
 
     return type_name
 
@@ -191,234 +212,40 @@ def generate_code(request, response):
     )
     template = env.get_template("template.py")
 
-    output_map = {}
+    output_files = collections.defaultdict()
+    # def log(message):
+    #     sys.stderr.write(f"{message}\n")
+
+    root_packages = {proto_file.package.split('.')[0] for proto_file in request.proto_file}
+
     for proto_file in request.proto_file:
         out = proto_file.package
         if out == "google.protobuf":
             continue
 
-        if not out:
-            out = os.path.splitext(proto_file.name)[0].replace(os.path.sep, ".")
+        if package:
+            output_file_name = os.path.sep.join(package.split('.') + ['__init__.py'])
+        else:
+            output_file_name = '__root__.py'
 
-        if out not in output_map:
-            output_map[out] = {"package": proto_file.package, "files": []}
-        output_map[out]["files"].append(proto_file)
+        # log(f"  output name:  {output_file_name}")
+
+        output_files.setdefault(output_file_name, {"package": package, "files": []})
+        output_files[output_file_name]["files"].append(proto_file)
 
     # TODO: Figure out how to handle gRPC request/response messages and add
     # processing below for Service.
 
-    for filename, options in output_map.items():
-        package = options["package"]
-        # print(package, filename, file=sys.stderr)
-        output = {
-            "package": package,
-            "files": [f.name for f in options["files"]],
-            "imports": set(),
-            "datetime_imports": set(),
-            "typing_imports": set(),
-            "messages": [],
-            "enums": [],
-            "services": [],
-        }
-
-        type_mapping = {}
-
-        for proto_file in options["files"]:
-            # print(proto_file.message_type, file=sys.stderr)
-            # print(proto_file.service, file=sys.stderr)
-            # print(proto_file.source_code_info, file=sys.stderr)
-
-            for item, path in traverse(proto_file):
-                # print(item, file=sys.stderr)
-                # print(path, file=sys.stderr)
-                data = {"name": item.name, "py_name": stringcase.pascalcase(item.name)}
-
-                if isinstance(item, DescriptorProto):
-                    # print(item, file=sys.stderr)
-                    if item.options.map_entry:
-                        # Skip generated map entry messages since we just use dicts
-                        continue
-
-                    data.update(
-                        {
-                            "type": "Message",
-                            "comment": get_comment(proto_file, path),
-                            "properties": [],
-                        }
-                    )
-
-                    for i, f in enumerate(item.field):
-                        t = py_type(package, output["imports"], item, f)
-                        zero = get_py_zero(f.type)
-
-                        repeated = False
-                        packed = False
-
-                        field_type = f.Type.Name(f.type).lower()[5:]
-
-                        field_wraps = ""
-                        if f.type_name.startswith(
-                            ".google.protobuf"
-                        ) and f.type_name.endswith("Value"):
-                            w = f.type_name.split(".").pop()[:-5].upper()
-                            field_wraps = f"betterproto.TYPE_{w}"
-
-                        map_types = None
-                        if f.type == 11:
-                            # This might be a map...
-                            message_type = f.type_name.split(".").pop().lower()
-                            # message_type = py_type(package)
-                            map_entry = f"{f.name.replace('_', '').lower()}entry"
-
-                            if message_type == map_entry:
-                                for nested in item.nested_type:
-                                    if (
-                                        nested.name.replace("_", "").lower()
-                                        == map_entry
-                                    ):
-                                        if nested.options.map_entry:
-                                            # print("Found a map!", file=sys.stderr)
-                                            k = py_type(
-                                                package,
-                                                output["imports"],
-                                                item,
-                                                nested.field[0],
-                                            )
-                                            v = py_type(
-                                                package,
-                                                output["imports"],
-                                                item,
-                                                nested.field[1],
-                                            )
-                                            t = f"Dict[{k}, {v}]"
-                                            field_type = "map"
-                                            map_types = (
-                                                f.Type.Name(nested.field[0].type),
-                                                f.Type.Name(nested.field[1].type),
-                                            )
-                                            output["typing_imports"].add("Dict")
-
-                        if f.label == 3 and field_type != "map":
-                            # Repeated field
-                            repeated = True
-                            t = f"List[{t}]"
-                            zero = "[]"
-                            output["typing_imports"].add("List")
-
-                            if f.type in [1, 2, 3, 4, 5, 6, 7, 8, 13, 15, 16, 17, 18]:
-                                packed = True
-
-                        one_of = ""
-                        if f.HasField("oneof_index"):
-                            one_of = item.oneof_decl[f.oneof_index].name
-
-                        if "Optional[" in t:
-                            output["typing_imports"].add("Optional")
-
-                        if "timedelta" in t:
-                            output["datetime_imports"].add("timedelta")
-                        elif "datetime" in t:
-                            output["datetime_imports"].add("datetime")
-
-                        data["properties"].append(
-                            {
-                                "name": f.name,
-                                "py_name": safe_snake_case(f.name),
-                                "number": f.number,
-                                "comment": get_comment(proto_file, path + [2, i]),
-                                "proto_type": int(f.type),
-                                "field_type": field_type,
-                                "field_wraps": field_wraps,
-                                "map_types": map_types,
-                                "type": t,
-                                "zero": zero,
-                                "repeated": repeated,
-                                "packed": packed,
-                                "one_of": one_of,
-                            }
-                        )
-                        # print(f, file=sys.stderr)
-
-                    output["messages"].append(data)
-                elif isinstance(item, EnumDescriptorProto):
-                    # print(item.name, path, file=sys.stderr)
-                    data.update(
-                        {
-                            "type": "Enum",
-                            "comment": get_comment(proto_file, path),
-                            "entries": [
-                                {
-                                    "name": v.name,
-                                    "value": v.number,
-                                    "comment": get_comment(proto_file, path + [2, i]),
-                                }
-                                for i, v in enumerate(item.value)
-                            ],
-                        }
-                    )
-
-                    output["enums"].append(data)
-
-            for i, service in enumerate(proto_file.service):
-                # print(service, file=sys.stderr)
-
-                data = {
-                    "name": service.name,
-                    "py_name": stringcase.pascalcase(service.name),
-                    "comment": get_comment(proto_file, [6, i]),
-                    "methods": [],
-                }
-
-                for j, method in enumerate(service.method):
-                    if method.client_streaming:
-                        raise NotImplementedError("Client streaming not yet supported")
-
-                    input_message = None
-                    input_type = get_ref_type(
-                        package, output["imports"], method.input_type
-                    ).strip('"')
-                    for msg in output["messages"]:
-                        if msg["name"] == input_type:
-                            input_message = msg
-                            for field in msg["properties"]:
-                                if field["zero"] == "None":
-                                    output["typing_imports"].add("Optional")
-                            break
-
-                    data["methods"].append(
-                        {
-                            "name": method.name,
-                            "py_name": stringcase.snakecase(method.name),
-                            "comment": get_comment(proto_file, [6, i, 2, j], indent=8),
-                            "route": f"/{package}.{service.name}/{method.name}",
-                            "input": get_ref_type(
-                                package, output["imports"], method.input_type
-                            ).strip('"'),
-                            "input_message": input_message,
-                            "output": get_ref_type(
-                                package, output["imports"], method.output_type, unwrap=False
-                            ).strip('"'),
-                            "client_streaming": method.client_streaming,
-                            "server_streaming": method.server_streaming,
-                        }
-                    )
-
-                    if method.server_streaming:
-                        output["typing_imports"].add("AsyncGenerator")
-
-                output["services"].append(data)
-
-        output["imports"] = sorted(output["imports"])
-        output["datetime_imports"] = sorted(output["datetime_imports"])
-        output["typing_imports"] = sorted(output["typing_imports"])
+    for output_file_name, output_file_data in output_files.items():
+        template_data = get_template_data(output_file_data)
 
         # Fill response
         f = response.file.add()
-        f.name = os.path.sep.join(filename.split('.') + ['__init__.py'])
+        f.name = output_file_name
 
         # Render and then format the output file.
         f.content = black.format_str(
-            template.render(description=output),
+            template.render(description=template_data),
             mode=black.FileMode(target_versions={black.TargetVersion.PY37}),
         )
 
@@ -426,6 +253,208 @@ def generate_code(request, response):
     for fname in filenames:
         print(f"Writing {fname}", file=sys.stderr)
 
+
+def get_template_data(options):
+    package = options["package"]
+    # print(package, filename, file=sys.stderr)
+    template_data = {
+        "package": package,
+        "files": [f.name for f in options["files"]],
+        "imports": set(),
+        "datetime_imports": set(),
+        "typing_imports": set(),
+        "messages": [],
+        "enums": [],
+        "services": [],
+    }
+    for proto_file in options["files"]:
+        # print(proto_file.message_type, file=sys.stderr)
+        # print(proto_file.service, file=sys.stderr)
+        # print(proto_file.source_code_info, file=sys.stderr)
+
+        for item, path in traverse(proto_file):
+            # print(item, file=sys.stderr)
+            # print(path, file=sys.stderr)
+            data = {"name": item.name, "py_name": stringcase.pascalcase(item.name)}
+
+            if isinstance(item, DescriptorProto):
+                # print(item, file=sys.stderr)
+                if item.options.map_entry:
+                    # Skip generated map entry messages since we just use dicts
+                    continue
+
+                data.update(
+                    {
+                        "type": "Message",
+                        "comment": get_comment(proto_file, path),
+                        "properties": [],
+                    }
+                )
+
+                for i, f in enumerate(item.field):
+                    t = py_type(package, template_data["imports"], item, f)
+                    zero = get_py_zero(f.type)
+
+                    repeated = False
+                    packed = False
+
+                    field_type = f.Type.Name(f.type).lower()[5:]
+
+                    field_wraps = ""
+                    if f.type_name.startswith(
+                        ".google.protobuf"
+                    ) and f.type_name.endswith("Value"):
+                        w = f.type_name.split(".").pop()[:-5].upper()
+                        field_wraps = f"betterproto.TYPE_{w}"
+
+                    map_types = None
+                    if f.type == 11:
+                        # This might be a map...
+                        message_type = f.type_name.split(".").pop().lower()
+                        # message_type = py_type(package)
+                        map_entry = f"{f.name.replace('_', '').lower()}entry"
+
+                        if message_type == map_entry:
+                            for nested in item.nested_type:
+                                if (
+                                    nested.name.replace("_", "").lower()
+                                    == map_entry
+                                ):
+                                    if nested.options.map_entry:
+                                        # print("Found a map!", file=sys.stderr)
+                                        k = py_type(
+                                            package,
+                                            template_data["imports"],
+                                            item,
+                                            nested.field[0],
+                                        )
+                                        v = py_type(
+                                            package,
+                                            template_data["imports"],
+                                            item,
+                                            nested.field[1],
+                                        )
+                                        t = f"Dict[{k}, {v}]"
+                                        field_type = "map"
+                                        map_types = (
+                                            f.Type.Name(nested.field[0].type),
+                                            f.Type.Name(nested.field[1].type),
+                                        )
+                                        template_data["typing_imports"].add("Dict")
+
+                    if f.label == 3 and field_type != "map":
+                        # Repeated field
+                        repeated = True
+                        t = f"List[{t}]"
+                        zero = "[]"
+                        template_data["typing_imports"].add("List")
+
+                        if f.type in [1, 2, 3, 4, 5, 6, 7, 8, 13, 15, 16, 17, 18]:
+                            packed = True
+
+                    one_of = ""
+                    if f.HasField("oneof_index"):
+                        one_of = item.oneof_decl[f.oneof_index].name
+
+                    if "Optional[" in t:
+                        template_data["typing_imports"].add("Optional")
+
+                    if "timedelta" in t:
+                        template_data["datetime_imports"].add("timedelta")
+                    elif "datetime" in t:
+                        template_data["datetime_imports"].add("datetime")
+
+                    data["properties"].append(
+                        {
+                            "name": f.name,
+                            "py_name": safe_snake_case(f.name),
+                            "number": f.number,
+                            "comment": get_comment(proto_file, path + [2, i]),
+                            "proto_type": int(f.type),
+                            "field_type": field_type,
+                            "field_wraps": field_wraps,
+                            "map_types": map_types,
+                            "type": t,
+                            "zero": zero,
+                            "repeated": repeated,
+                            "packed": packed,
+                            "one_of": one_of,
+                        }
+                    )
+                    # print(f, file=sys.stderr)
+
+                template_data["messages"].append(data)
+            elif isinstance(item, EnumDescriptorProto):
+                # print(item.name, path, file=sys.stderr)
+                data.update(
+                    {
+                        "type": "Enum",
+                        "comment": get_comment(proto_file, path),
+                        "entries": [
+                            {
+                                "name": v.name,
+                                "value": v.number,
+                                "comment": get_comment(proto_file, path + [2, i]),
+                            }
+                            for i, v in enumerate(item.value)
+                        ],
+                    }
+                )
+
+                template_data["enums"].append(data)
+
+        for i, service in enumerate(proto_file.service):
+            # print(service, file=sys.stderr)
+
+            data = {
+                "name": service.name,
+                "py_name": stringcase.pascalcase(service.name),
+                "comment": get_comment(proto_file, [6, i]),
+                "methods": [],
+            }
+
+            for j, method in enumerate(service.method):
+                if method.client_streaming:
+                    raise NotImplementedError("Client streaming not yet supported")
+
+                input_message = None
+                input_type = get_ref_type(
+                    package, template_data["imports"], method.input_type
+                ).strip('"')
+                for msg in template_data["messages"]:
+                    if msg["name"] == input_type:
+                        input_message = msg
+                        for field in msg["properties"]:
+                            if field["zero"] == "None":
+                                template_data["typing_imports"].add("Optional")
+                        break
+
+                data["methods"].append(
+                    {
+                        "name": method.name,
+                        "py_name": stringcase.snakecase(method.name),
+                        "comment": get_comment(proto_file, [6, i, 2, j], indent=8),
+                        "route": f"/{package}.{service.name}/{method.name}",
+                        "input": get_ref_type(
+                            package, template_data["imports"], method.input_type
+                        ).strip('"'),
+                        "input_message": input_message,
+                        "output": get_ref_type(
+                            package, template_data["imports"], method.output_type, unwrap=False
+                        ).strip('"'),
+                        "client_streaming": method.client_streaming,
+                        "server_streaming": method.server_streaming,
+                    }
+                )
+
+                if method.server_streaming:
+                    template_data["typing_imports"].add("AsyncGenerator")
+
+            template_data["services"].append(data)
+    template_data["imports"] = sorted(template_data["imports"])
+    template_data["datetime_imports"] = sorted(template_data["datetime_imports"])
+    template_data["typing_imports"] = sorted(template_data["typing_imports"])
+    return template_data
 
 def main():
     """The plugin's main entry point."""

--- a/betterproto/tests/generate.py
+++ b/betterproto/tests/generate.py
@@ -48,13 +48,19 @@ if __name__ == "__main__":
         proto_files = get_files(".proto")
         json_files = get_files(".json")
 
+    if os.name == 'nt':
+        plugin_path = os.path.join('..', 'plugin.bat')
+    else:
+        plugin_path = os.path.join('..', 'plugin.py')
+    
+
     for filename in proto_files:
         print(f"Generating code for {os.path.basename(filename)}")
         subprocess.run(
             f"protoc --python_out=. {os.path.basename(filename)}", shell=True
         )
         subprocess.run(
-            f"protoc --plugin=protoc-gen-custom=../plugin.py --custom_out=. {os.path.basename(filename)}",
+            f"protoc --plugin=protoc-gen-custom={plugin_path} --custom_out=. {os.path.basename(filename)}",
             shell=True,
         )
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="betterproto",
-    version="1.2.2",
+    version="1.2.3",
     description="A better Protobuf / gRPC generator & library",
     long_description=open("README.md", "r").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes lots of issues with imports.

## Circular imports

two python files referring to eachother, preventing imports

I've solved this by wrapping generated Types in quotes (`List["Foo"]`)

## Imports from parent package

I've solved this for now by using absolute imports there, but I think this still needs a change to use `from ... import [parent]` instead.

## Module and filename conflicts  

consider two messages `animal.domestic.cow`, and `animal.bird` which is in the `animal.proto` file. the python files would look like  
```
animal/domestic/cow.py
animal.py
```
  that means `animal` is now both a file and a module, and it results in conflicts.

I've solved this by exporting _all_ packages as modules:

```
animal/
   __init__.py  # contains bird
   domestic/
     __init__.py  # contains cow
```

You can import the animal package simply with `import animal` as before, but still also `import animal.domestic`.


## import name conflicts

Importing two subpackages with the same name resulted in conflicts. See: #25 

Solved this by always aliasing the imported package with full package path:

`import from .aedt.method_data import v0 as aedt_method_data_v0`


## relative imports

Relative imports work correctly for siblings, children and descendants.
