### PR TITLE
Only import types from grpclib when type checking

### DIFF
--- a/betterproto/__init__.py
+++ b/betterproto/__init__.py
@@ -1015,10 +1015,10 @@ class ServiceStub(ABC):
 
     def __init__(
         self,
-        channel: 'Channel',
+        channel: "Channel",
         *,
         timeout: Optional[float] = None,
-        deadline: Optional['Deadline'] = None,
+        deadline: Optional["Deadline"] = None,
         metadata: Optional[_MetadataLike] = None,
     ) -> None:
         self.channel = channel
@@ -1029,7 +1029,7 @@ class ServiceStub(ABC):
     def __resolve_request_kwargs(
         self,
         timeout: Optional[float],
-        deadline: Optional['Deadline'],
+        deadline: Optional["Deadline"],
         metadata: Optional[_MetadataLike],
     ):
         return {
@@ -1045,7 +1045,7 @@ class ServiceStub(ABC):
         response_type: Type[T],
         *,
         timeout: Optional[float] = None,
-        deadline: Optional['Deadline'] = None,
+        deadline: Optional["Deadline"] = None,
         metadata: Optional[_MetadataLike] = None,
     ) -> T:
         """Make a unary request and return the response."""
@@ -1068,7 +1068,7 @@ class ServiceStub(ABC):
         response_type: Type[T],
         *,
         timeout: Optional[float] = None,
-        deadline: Optional['Deadline'] = None,
+        deadline: Optional["Deadline"] = None,
         metadata: Optional[_MetadataLike] = None,
     ) -> AsyncGenerator[T, None]:
         """Make a unary request and return the stream response iterator."""

--- a/betterproto/__init__.py
+++ b/betterproto/__init__.py
@@ -27,7 +27,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
-import grpclib.client
+
 import grpclib.const
 import stringcase
 
@@ -35,6 +35,8 @@ from .casing import safe_snake_case
 
 if TYPE_CHECKING:
     from grpclib._protocols import IProtoMessage
+    from grpclib.client import Channel
+    from grpclib.metadata import Deadline
 
 if not (sys.version_info.major == 3 and sys.version_info.minor >= 7):
     # Apply backport of datetime.fromisoformat from 3.7
@@ -1013,10 +1015,10 @@ class ServiceStub(ABC):
 
     def __init__(
         self,
-        channel: grpclib.client.Channel,
+        channel: 'Channel',
         *,
         timeout: Optional[float] = None,
-        deadline: Optional[grpclib.metadata.Deadline] = None,
+        deadline: Optional['Deadline'] = None,
         metadata: Optional[_MetadataLike] = None,
     ) -> None:
         self.channel = channel
@@ -1027,7 +1029,7 @@ class ServiceStub(ABC):
     def __resolve_request_kwargs(
         self,
         timeout: Optional[float],
-        deadline: Optional[grpclib.metadata.Deadline],
+        deadline: Optional['Deadline'],
         metadata: Optional[_MetadataLike],
     ):
         return {
@@ -1043,7 +1045,7 @@ class ServiceStub(ABC):
         response_type: Type[T],
         *,
         timeout: Optional[float] = None,
-        deadline: Optional[grpclib.metadata.Deadline] = None,
+        deadline: Optional['Deadline'] = None,
         metadata: Optional[_MetadataLike] = None,
     ) -> T:
         """Make a unary request and return the response."""
@@ -1066,7 +1068,7 @@ class ServiceStub(ABC):
         response_type: Type[T],
         *,
         timeout: Optional[float] = None,
-        deadline: Optional[grpclib.metadata.Deadline] = None,
+        deadline: Optional['Deadline'] = None,
         metadata: Optional[_MetadataLike] = None,
     ) -> AsyncGenerator[T, None]:
         """Make a unary request and return the stream response iterator."""

--- a/betterproto/plugin.py
+++ b/betterproto/plugin.py
@@ -122,7 +122,7 @@ def get_py_zero(type_num: int) -> str:
 
 
 def traverse(proto_file):
-    def _traverse(path, items, prefix = ''):
+    def _traverse(path, items, prefix=""):
         for i, item in enumerate(items):
             # Adjust the name since we flatten the heirarchy.
             item.name = next_prefix = prefix + item.name

--- a/betterproto/tests/test_features.py
+++ b/betterproto/tests/test_features.py
@@ -256,7 +256,7 @@ def test_to_dict_default_values():
         some_double: float = betterproto.double_field(2)
         some_message: TestChildMessage = betterproto.message_field(3)
 
-    test = TestParentMessage().from_dict({"someInt": 0, "someDouble": 1.2,})
+    test = TestParentMessage().from_dict({"someInt": 0, "someDouble": 1.2})
 
     assert test.to_dict(include_default_values=True) == {
         "someInt": 0,

--- a/betterproto/tests/test_service_stub.py
+++ b/betterproto/tests/test_service_stub.py
@@ -29,7 +29,7 @@ class ExampleService:
                 grpclib.const.Cardinality.UNARY_UNARY,
                 DoThingRequest,
                 DoThingResponse,
-            ),
+            )
         }
 
 
@@ -94,7 +94,9 @@ async def test_service_call_lower_level_with_overrides():
     ) as channel:
         stub = ExampleServiceStub(channel, deadline=deadline, metadata=metadata)
         response = await stub._unary_unary(
-            "/service.ExampleService/DoThing", DoThingRequest(ITERATIONS), DoThingResponse,
+            "/service.ExampleService/DoThing",
+            DoThingRequest(ITERATIONS),
+            DoThingResponse,
             deadline=kwarg_deadline,
             metadata=kwarg_metadata,
         )
@@ -116,7 +118,9 @@ async def test_service_call_lower_level_with_overrides():
     ) as channel:
         stub = ExampleServiceStub(channel, deadline=deadline, metadata=metadata)
         response = await stub._unary_unary(
-            "/service.ExampleService/DoThing", DoThingRequest(ITERATIONS), DoThingResponse,
+            "/service.ExampleService/DoThing",
+            DoThingRequest(ITERATIONS),
+            DoThingResponse,
             timeout=kwarg_timeout,
             metadata=kwarg_metadata,
         )


### PR DESCRIPTION
#37  This speeds up initial import and reduces the memory foot print.

Also ran black.