### PR TITLE
Rearrange plugin import to make import errors more helpful

### DIFF
--- a/betterproto/plugin.py
+++ b/betterproto/plugin.py
@@ -1,33 +1,37 @@
 #!/usr/bin/env python
 
+from collections import defaultdict
 import itertools
 import os.path
+import stringcase
 import sys
 import textwrap
-from collections import defaultdict
 from typing import Dict, List, Optional, Type
+from betterproto.casing import safe_snake_case
 
 try:
+    # betterproto[compiler] specific dependencies
     import black
-except ImportError:
+    from google.protobuf.compiler import plugin_pb2 as plugin
+    from google.protobuf.descriptor_pb2 import (
+        DescriptorProto,
+        EnumDescriptorProto,
+        FieldDescriptorProto,
+    )
+    import google.protobuf.wrappers_pb2 as google_wrappers
+    import jinja2
+except ImportError as err:
+    missing_import = err.args[0][17:-1]
     print(
-        "Unable to import `black` formatter. Did you install the compiler feature with `pip install betterproto[compiler]`?"
+        "\033[31m"
+        f"Unable to import `{missing_import}` from betterproto plugin! "
+        "Please ensure that you've installed betterproto as "
+        '`pip install "betterproto[compiler]"` so that compiler dependencies '
+        "are included."
+        "\033[0m"
     )
     raise SystemExit(1)
 
-import jinja2
-import stringcase
-
-from google.protobuf.compiler import plugin_pb2 as plugin
-from google.protobuf.descriptor_pb2 import (
-    DescriptorProto,
-    EnumDescriptorProto,
-    FieldDescriptorProto,
-)
-
-from betterproto.casing import safe_snake_case
-
-import google.protobuf.wrappers_pb2 as google_wrappers
 
 WRAPPER_TYPES: Dict[str, Optional[Type]] = defaultdict(
     lambda: None,

--- a/betterproto/tests/inputs/config.py
+++ b/betterproto/tests/inputs/config.py
@@ -11,7 +11,7 @@ tests = {
     "googletypes_service_returns_empty",  # 9
     "casing_message_field_uppercase",  # 11
     "namespace_keywords",  # 70
-    "namespace_builtin_types"  # 53
+    "namespace_builtin_types",  # 53
 }
 
 services = {


### PR DESCRIPTION
This addresses an issue where if the user happens to have black installed in their environment but not the other dependencies when running the protoc plugin then the resulting import error (No module named 'google') is not very helpful.