### PR TITLE
Support running plugin without installing betterproto

### DIFF
--- a/betterproto/plugin.py
+++ b/betterproto/plugin.py
@@ -2,14 +2,17 @@
 
 import itertools
 import os.path
+import pathlib
 import re
 import stringcase
 import sys
 import textwrap
 from typing import List
+
+sys.path.append(str(pathlib.Path(__file__).parent.parent))  # add betterproto to path
+import betterproto
 from betterproto.casing import safe_snake_case
 from betterproto.compile.importing import get_ref_type
-import betterproto
 
 try:
     # betterproto[compiler] specific dependencies


### PR DESCRIPTION
Let's us run protoc with `betterproto/plugin.py` , without installing betterproto

```bash
git clone git@github.com:danielgtaylor/python-betterproto.git betterproto-script-demo
cd betterproto-script-demo
pipenv install --ignore-pipfile
mkdir example
pipenv run protoc \
  --plugin=protoc-gen-custom=betterproto/plugin.py \
  --custom_out=example \
  betterproto/tests/inputs/bool/bool.proto
```


**Before**:

```yaml
Traceback (most recent call last):
  File "betterproto/plugin.py", line 10, in <module>
    from betterproto.casing import safe_snake_case
ModuleNotFoundError: No module named 'betterproto'
--custom_out: protoc-gen-custom: Plugin failed with status code 1.
```

Here you needed to install `betterproto` so it can reference itself when run from as plugin (script)


**After**

```
Writing __init__.py
Writing betterproto/tests/inputs/__init__.py
Writing betterproto/tests/inputs/bool/__init__.py
Writing betterproto/tests/inputs/bool/bool.py
```
