### PR TITLE
Support lists of non-protobufs in Message.to_dict

### DIFF
--- a/betterproto/__init__.py
+++ b/betterproto/__init__.py
@@ -818,7 +818,13 @@ class Message(ABC):
                         output[cased_name] = v
                 elif isinstance(v, list):
                     # Convert each item.
-                    v = [i.to_dict(casing, include_default_values) for i in v]
+                    new = v
+                    for i in v:
+                        if isinstance(i, Message):
+                            new.append(i.to_dict(casing, include_default_values))
+                        else:
+                            new.append(i)
+                    v = new
                     if v or include_default_values:
                         output[cased_name] = v
                 else:

--- a/betterproto/__init__.py
+++ b/betterproto/__init__.py
@@ -818,13 +818,10 @@ class Message(ABC):
                         output[cased_name] = v
                 elif isinstance(v, list):
                     # Convert each item.
-                    new = v
-                    for i in v:
-                        if isinstance(i, Message):
-                            new.append(i.to_dict(casing, include_default_values))
-                        else:
-                            new.append(i)
-                    v = new
+                    try:
+                        v = [i.to_dict(casing, include_default_values) for i in v]
+                    except AttributeError:
+                        pass
                     if v or include_default_values:
                         output[cased_name] = v
                 else:


### PR DESCRIPTION
Currently if you have a Message with a typing.List field of anything that isn't a Message, it will fail to convert due to it raising an AttributeError.

This can be fixed with a simple instance check before appending to the list.