### PR TITLE
Add missing async/await keywords when casing

### DIFF
--- a/betterproto/casing.py
+++ b/betterproto/casing.py
@@ -20,6 +20,8 @@ def safe_snake_case(value: str) -> str:
         "and",
         "as",
         "assert",
+        "async",
+        "await",
         "break",
         "class",
         "continue",


### PR DESCRIPTION
Simple change to extend list of python keywords to include `async` and `await`. This was causing failures in `make generate` when `black` attempted to format generated file for `namespace_keywords`.