### PR TITLE
Handle mutable default arguments cleanly

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -476,6 +476,20 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+category = "dev"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+name = "pytest-mock"
+optional = false
+python-versions = ">=3.5"
+version = "3.1.1"
+
+[package.dependencies]
+pytest = ">=2.7"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
 category = "main"
 description = "Alternative regular expression module, to replace re."
 name = "regex"
@@ -623,7 +637,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 compiler = ["black", "jinja2", "protobuf"]
 
 [metadata]
-content-hash = "375411698ec644810d09af809ac8a004abc9821f0b718178505424625f407c14"
+content-hash = "7a2aa57a3a2b58e70aa05be75bff08272c2f070ecc1872a1c825f228299b82c2"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -971,6 +985,10 @@ pytest-asyncio = [
 pytest-cov = [
     {file = "pytest-cov-2.10.0.tar.gz", hash = "sha256:1a629dc9f48e53512fcbfda6b07de490c374b0c83c55ff7a1720b3fccff0ac87"},
     {file = "pytest_cov-2.10.0-py2.py3-none-any.whl", hash = "sha256:6e6d18092dce6fad667cd7020deed816f858ad3b49d5b5e2b1cc1c97a4dba65c"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.1.1.tar.gz", hash = "sha256:636e792f7dd9e2c80657e174c04bf7aa92672350090736d82e97e92ce8f68737"},
+    {file = "pytest_mock-3.1.1-py3-none-any.whl", hash = "sha256:a9fedba70e37acf016238bb2293f2652ce19985ceb245bbd3d7f3e4032667402"},
 ]
 regex = [
     {file = "regex-2020.6.8-cp27-cp27m-win32.whl", hash = "sha256:fbff901c54c22425a5b809b914a3bfaf4b9570eee0e5ce8186ac71eb2025191c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ protobuf = "^3.12.2"
 pytest = "^5.4.2"
 pytest-asyncio = "^0.12.0"
 pytest-cov = "^2.9.0"
+pytest-mock = "^3.1.1"
 tox = "^3.15.1"
 
 [tool.poetry.scripts]

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -80,6 +80,10 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
 {{ method.comment }}
 
         {% endif %}
+        {%- for py_name, zero in method.mutable_default_args %}
+        {{ py_name }} = {{ py_name }} or {{ zero }}
+        {% endfor %}
+
         {% if not method.client_streaming %}
         request = {{ method.input }}()
         {% for field in method.input_message.properties %}

--- a/tests/inputs/service/service.proto
+++ b/tests/inputs/service/service.proto
@@ -4,6 +4,7 @@ package service;
 
 message DoThingRequest {
   string name = 1;
+  repeated string comments = 2;
 }
 
 message DoThingResponse {


### PR DESCRIPTION
When generating code, ensure that default list/dict arguments are initialised in local scope if unspecified or `None`.

The following diff shows the difference in the generated source file from `service.proto`.
```diff
5c5
< from typing import AsyncIterable, AsyncIterator, Iterable, List, Union
---
> from typing import AsyncIterable, AsyncIterator, Iterable, List, Optional, Union
35c35
<         self, *, name: str = "", comments: List[str] = []
---
>         self, *, name: str = "", comments: Optional[List[str]] = None
36a37
>         comments = comments or []
```

Due to the nature of the issue, the included test simply verifies that the default list instance initialised is not the same object used in any subsequent calls. This is done so by intercepting the calls made to the underlying `ServiceStub._unary_unary` method and verifying that the `comments` instance is not reusing the object.