### PR TITLE
Use poetry-core as PEP 517 build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,5 +77,5 @@ commands =
 """
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0,<2"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This change replaces the use of poetry as the build backend in favour
of the leaner poetry-core. This speeds up PEP-517 builds for source
installs, tox environment setup etc.