### PR TITLE
Speed up poetry install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
             ${{ runner.os }}-poetry-
       - name: Install dependencies
         run: |
+          poetry run pip install --upgrade pip
           poetry install
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ datetime.datetime(2019, 1, 1, 11, 59, 58, 800000, tzinfo=datetime.timezone.utc)
 
 ```sh
 # Get set up with the virtual env & dependencies
+poetry run pip install --upgrade pip
 poetry install
 
 # Activate the poetry environment


### PR DESCRIPTION
Ensure `poetry run pip install --upgrade pip` is run before `poetry install` to avoid compiling dependencies from source

- It took 14 minutes to install dependencies on python 3.6 because it comes with an older `pip`, for which `grpcio` does not have wheels available. Pip will then compile from source, taking a long time.
- On my system (ubuntu 18, which came with pip 9) it took 20 minutes