### PR TITLE
Fix the readme gRPC usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,8 @@ async def main():
 
     # don't forget to close the channel when done!
     channel.close()
-
-
-asyncio.run(main())
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ This project exists because I am unhappy with the state of the official Google p
   - Uses `SerializeToString()` rather than the built-in `__bytes__()`
   - Special wrapped types don't use Python's `None`
   - Timestamp/duration types don't use Python's built-in `datetime` module
-
 This project is a reimplementation from the ground up focused on idiomatic modern Python to help fix some of the above. While it may not be a 1:1 drop-in replacement due to changed method names and call patterns, the wire format is identical.
 
 ## Installation
@@ -126,7 +125,7 @@ Greeting(message="Hey!")
 
 The generated Protobuf `Message` classes are compatible with [grpclib](https://github.com/vmagamedov/grpclib) so you are free to use it if you like. That said, this project also includes support for async gRPC stub generation with better static type checking and code completion support. It is enabled by default.
 
-Given an example like:
+Given an example service definition:
 
 ```protobuf
 syntax = "proto3";
@@ -153,22 +152,34 @@ service Echo {
 }
 ```
 
-You can use it like so (enable async in the interactive shell first):
-
+A client can be implemented as follows:
 ```python
->>> import echo
->>> from grpclib.client import Channel
+import echo
+from grpclib.client import Channel
+import asyncio
 
->>> channel = Channel(host="127.0.0.1", port=1234)
->>> service = echo.EchoStub(channel)
->>> await service.echo(value="hello", extra_times=1)
-EchoResponse(values=["hello", "hello"])
 
->>> async for response in service.echo_stream(value="hello", extra_times=1)
+async def main():
+    channel = Channel(host="127.0.0.1", port=50051)
+    service = echo.EchoStub(channel)
+    print(await service.echo(value="hello", extra_times=1))
+
+    async for response in service.echo_stream(value="hello", extra_times=1):
         print(response)
 
-EchoStreamResponse(value="hello")
-EchoStreamResponse(value="hello")
+    # don't forget to close the channel when done!
+    channel.close()
+
+
+asyncio.run(main())
+
+```
+
+which would output
+```python
+EchoResponse(values=['hello', 'hello'])
+EchoStreamResponse(value='hello')
+EchoStreamResponse(value='hello')
 ```
 
 ### JSON

--- a/README.md
+++ b/README.md
@@ -171,11 +171,13 @@ async def main():
 
     # don't forget to close the channel when done!
     channel.close()
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main())
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())
 
 ```
-
 which would output
 ```python
 EchoResponse(values=['hello', 'hello'])

--- a/README.md
+++ b/README.md
@@ -154,15 +154,17 @@ service Echo {
 
 A client can be implemented as follows:
 ```python
-import echo
-from grpclib.client import Channel
 import asyncio
+import echo
+
+from grpclib.client import Channel
 
 
 async def main():
     channel = Channel(host="127.0.0.1", port=50051)
     service = echo.EchoStub(channel)
-    print(await service.echo(value="hello", extra_times=1))
+    response = await service.echo(value="hello", extra_times=1)
+    print(response)
 
     async for response in service.echo_stream(value="hello", extra_times=1):
         print(response)


### PR DESCRIPTION
The sample gRPC client implementation in the readme had two defects in it which this PR corrects.

The first is a simple syntax error in the `async for` line, and should require no further explanation.

The second is a library usage error relating to the application of `grpclib.client.Channel`.
The issue stems from `grpclib.client.Channel` needing to be manually closed at the end of the session, which the readme example failed to do. This leads to runtime warnings when the channel object gets GC'ed.
As discussed in slack, not calling `channel.close()` is a implementation error and is the primary motivation of this PR.

Changes in tone:
I rewrote the client example to run from a script file instead of assuming a REPL, which I believe to be more realistic a use case. 

The other examples in the README are, imho, sufficient to demonstrate the intended functionality.