### PR TITLE
Support for recursive messages

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -530,7 +530,7 @@ class Message(ABC):
         return super().__getattribute__(name)
 
     def __eq__(self, other):
-        if type(self) != type(other):
+        if type(self) is not type(other):
             return False
 
         equal = True
@@ -558,7 +558,7 @@ class Message(ABC):
             if value is PLACEHOLDER:
                 continue
             found = True
-            parts.extend([field_name, "=", repr(value), ","])
+            parts.extend([field_name, "=", repr(value), ", "])
 
         if found:
             parts.pop()

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -550,20 +550,15 @@ class Message(ABC):
 
         return equal
 
-    def __repr__(self):
-        parts = [self.__class__.__name__, "("]
-        found = False
+    def __repr__(self) -> str:
+        parts = []
         for field_name in self._betterproto.meta_by_field_name:
             value = self.__raw_get(field_name)
             if value is PLACEHOLDER:
                 continue
-            found = True
-            parts.extend([field_name, "=", repr(value), ", "])
+            parts.append(f"{field_name}={value!r}")
 
-        if found:
-            parts.pop()
-        parts.append(")")
-        return "".join(parts)
+        return f"{self.__class__.__name__}({', '.join(parts)})"
 
     def __getattribute__(self, name: str) -> Any:
         value = super().__getattribute__(name)

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -529,26 +529,25 @@ class Message(ABC):
     def __raw_get(self, name: str) -> Any:
         return super().__getattribute__(name)
 
-    def __eq__(self, other):
+    def __eq__(self, other: T) -> bool:
         if type(self) is not type(other):
             return False
 
-        equal = True
         for field_name in self._betterproto.meta_by_field_name:
             self_val = self.__raw_get(field_name)
             other_val = other.__raw_get(field_name)
             if self_val is PLACEHOLDER and other_val is PLACEHOLDER:
                 continue
-            elif self_val is PLACEHOLDER:
+
+            if self_val is PLACEHOLDER:
                 self_val = self._get_field_default(field_name)
             elif other_val is PLACEHOLDER:
                 other_val = other._get_field_default(field_name)
 
             if self_val != other_val:
-                equal = False
-                break
+                return False
 
-        return equal
+        return True
 
     def __repr__(self) -> str:
         parts = []

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -550,6 +550,21 @@ class Message(ABC):
 
         return equal
 
+    def __repr__(self):
+        parts = [self.__class__.__name__, "("]
+        found = False
+        for field_name in self._betterproto.meta_by_field_name:
+            value = self.__raw_get(field_name)
+            if value is PLACEHOLDER:
+                continue
+            found = True
+            parts.extend([field_name, "=", repr(value), ","])
+
+        if found:
+            parts.pop()
+        parts.append(")")
+        return "".join(parts)
+
     def __getattribute__(self, name: str) -> Any:
         value = super().__getattribute__(name)
         if value is not PLACEHOLDER:

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -37,7 +37,7 @@ class {{ enum.py_name }}(betterproto.Enum):
 {% endfor %}
 {% endif %}
 {% for message in output_file.messages %}
-@dataclass(eq=False)
+@dataclass(eq=False, repr=False)
 class {{ message.py_name }}(betterproto.Message):
     {% if message.comment %}
 {{ message.comment }}

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -82,7 +82,7 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
                                             Optional[{{ field.annotation }}]
                                          {%- else -%}
                                             {{ field.annotation }}
-                                         {%- endif -%} =
+                                         {%- endif -%} = 
                                             {%- if field.py_name not in method.mutable_default_args -%}
                                                 {{ field.default_value_string }}
                                             {%- else -%}

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -37,7 +37,7 @@ class {{ enum.py_name }}(betterproto.Enum):
 {% endfor %}
 {% endif %}
 {% for message in output_file.messages %}
-@dataclass
+@dataclass(eq=False)
 class {{ message.py_name }}(betterproto.Message):
     {% if message.comment %}
 {{ message.comment }}
@@ -82,7 +82,7 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
                                             Optional[{{ field.annotation }}]
                                          {%- else -%}
                                             {{ field.annotation }}
-                                         {%- endif -%} = 
+                                         {%- endif -%} =
                                             {%- if field.py_name not in method.mutable_default_args -%}
                                                 {{ field.default_value_string }}
                                             {%- else -%}

--- a/tests/inputs/recursivemessage/recursivemessage.json
+++ b/tests/inputs/recursivemessage/recursivemessage.json
@@ -1,0 +1,12 @@
+{
+  "name": "Zues",
+  "child": {
+    "name": "Hercules"
+  },
+  "intermediate": {
+    "child": {
+      "name": "Douglas Adams"
+    },
+    "number": 42
+  }
+}

--- a/tests/inputs/recursivemessage/recursivemessage.proto
+++ b/tests/inputs/recursivemessage/recursivemessage.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+message Test {
+    string name = 1;
+    Test child = 2;
+    Intermediate intermediate = 3;
+}
+
+
+message Intermediate {
+    int32 number = 1;
+    Test child = 2;
+}

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -341,5 +341,5 @@ def test_message_repr():
     assert repr(RecursiveMessage(foo=1)) == "RecursiveMessage(foo=1)"
     assert (
         repr(RecursiveMessage(child=RecursiveMessage(), foo=1))
-        == "RecursiveMessage(child=RecursiveMessage(),foo=1)"
+        == "RecursiveMessage(child=RecursiveMessage(), foo=1)"
     )

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -317,3 +317,20 @@ def test_oneof_default_value_set_causes_writes_wire():
         == betterproto.which_one_of(_round_trip_serialization(foo3), "group1")
         == ("", None)
     )
+
+
+@dataclass(eq=False)
+class RecursiveMessage(betterproto.Message):
+    child: "RecursiveMessage" = betterproto.message_field(1)
+
+
+def test_recursive_message():
+    msg = RecursiveMessage()
+
+    assert msg.child == RecursiveMessage()
+
+    # Lazily-created zero-value children must not affect equality.
+    assert msg == RecursiveMessage()
+
+    # Lazily-created zero-value children must not affect serialization.
+    assert bytes(msg) == b""

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -319,9 +319,10 @@ def test_oneof_default_value_set_causes_writes_wire():
     )
 
 
-@dataclass(eq=False)
+@dataclass(eq=False, repr=False)
 class RecursiveMessage(betterproto.Message):
     child: "RecursiveMessage" = betterproto.message_field(1)
+    foo: int = betterproto.int32_field(2)
 
 
 def test_recursive_message():
@@ -334,3 +335,11 @@ def test_recursive_message():
 
     # Lazily-created zero-value children must not affect serialization.
     assert bytes(msg) == b""
+
+
+def test_message_repr():
+    assert repr(RecursiveMessage(foo=1)) == "RecursiveMessage(foo=1)"
+    assert (
+        repr(RecursiveMessage(child=RecursiveMessage(), foo=1))
+        == "RecursiveMessage(child=RecursiveMessage(),foo=1)"
+    )


### PR DESCRIPTION
Changes message initialization (`__post_init__`) so that default values are no longer eagerly created to prevent infinite recursion when initializing recursive messages.

As a result, `PLACEHOLDER` will be present in the message for any uninitialized fields.  So, an implementation of `__get_attribute__` is added that checks for `PLACEHOLDER` and lazily creates and stores default field values.

And, because `PLACEHOLDER` values don't compare equal with zero values, a custom implementation of `__eq__` is provided, and the code generation template is updated so that messages generate with `@dataclass(eq=False, repr=False)`.

Fixes #13 and fixes #74.

---

This needs careful review!  I'm not sure if this is the desired approach.  It's just the least-friction way I could think of.