### PR TITLE
Relax black version constraints

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -665,7 +665,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 compiler = ["black", "jinja2", "protobuf"]
 
 [metadata]
-content-hash = "2865ad5cb61c4a3ea255d6329a2f7a469dd6f77487f2e5e6634d320fa9258e82"
+content-hash = "6bd0923315785f42562ab1c7f3de73a20858fd7ebd6cc089f916cfc4719eac83"
 lock-version = "1.0"
 python-versions = "^3.6"
 
@@ -1061,7 +1061,6 @@ regex = [
     {file = "regex-2020.7.14-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5ea81ea3dbd6767873c611687141ec7b06ed8bab43f68fad5b7be184a920dc99"},
     {file = "regex-2020.7.14-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:bbb332d45b32df41200380fff14712cb6093b61bd142272a10b16778c418e98e"},
     {file = "regex-2020.7.14-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c11d6033115dc4887c456565303f540c44197f4fc1a2bfb192224a301534888e"},
-    {file = "regex-2020.7.14-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:75aaa27aa521a182824d89e5ab0a1d16ca207318a6b65042b046053cfc8ed07a"},
     {file = "regex-2020.7.14-cp38-cp38-win32.whl", hash = "sha256:d6cff2276e502b86a25fd10c2a96973fdb45c7a977dca2138d661417f3728341"},
     {file = "regex-2020.7.14-cp38-cp38-win_amd64.whl", hash = "sha256:7a2dd66d2d4df34fa82c9dc85657c5e019b87932019947faece7983f2089a840"},
     {file = "regex-2020.7.14.tar.gz", hash = "sha256:3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.6"
 backports-datetime-fromisoformat = { version = "^1.0.0", python = "<3.7" }
-black = { version = "^20.8b1", optional = true }
+black = { version = ">=19.3b0", optional = true }
 dataclasses = { version = "^0.7", python = ">=3.6, <3.7" }
 grpclib = "^0.3.1"
 jinja2 = { version = "^2.11.2", optional = true }


### PR DESCRIPTION
This change ensures that the wheel built only requests for the minimum version of black it requires to function as intended. Without this change any project that uses betterproto[compiler] would break while resolving dependencies.

#### Example scenario
Project A depends on `betterproto[compiler]` and `black (>=19.10b0 <20.0.0)`. This causes a resolution error as `betterproto` requires `20.8b1`of black which does not meet the project's constraint on `black`.
