### PR TITLE
Added example of calling protoc from python

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ message Greeting {
 }
 ```
 
-You can run the following:
+You can run the following to invoke protoc directly:
 
 ```sh
 mkdir lib
 protoc -I . --python_betterproto_out=lib example.proto
 ```
 
-or
+or run the following to invoke protoc via grpcio-tools:
 
 ```sh
 pip install grpcio-tools

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ mkdir lib
 protoc -I . --python_betterproto_out=lib example.proto
 ```
 
+or
+
+```sh
+pip install grpcio-tools
+python -m grpc_tools.protoc -I . --python_betterproto_out=lib example.proto
+```
+
 This will generate `lib/hello/__init__.py` which looks like:
 
 ```python


### PR DESCRIPTION
Took me a couple of minutes to figure out that this project didn't generate a binary called `protoc` when installed via pip so I added an example to the readme which would have helped me in this case.