### PR TITLE
Fix CI: replace now-disabled set-env command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install poetry
-          echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
 
       - name: Configure poetry
         shell: bash


### PR DESCRIPTION
[GitHub recently disabled the `set-env` command.](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) This is a fix sent to me by @abn that resolves the issue.