### PR TITLE
to_dict on empty nested types

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -972,6 +972,8 @@ class Message(ABC):
                     )
                 ):
                     output[cased_name] = value.to_dict(casing, include_default_values)
+                else:
+                    output[cased_name] = {}
             elif meta.proto_type == TYPE_MAP:
                 for k in value:
                     if hasattr(value[k], "to_dict"):


### PR DESCRIPTION
The issue is described [here #199](https://github.com/danielgtaylor/python-betterproto/issues/199).

It was a very simple fix. I don't think a test case is neccesary for this bug. If you think otherwise I can add one.