### PR TITLE
Grpcio support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dataclasses = { version = "^0.7", python = ">=3.6, <3.7" }
 grpclib = "^0.4.1"
 jinja2 = { version = "^2.11.2", optional = true }
 protobuf = { version = "^3.12.2", optional = true }
+grpcio = { version = "^1.35.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"
@@ -42,6 +43,7 @@ protoc-gen-python_betterproto = "betterproto.plugin:main"
 
 [tool.poetry.extras]
 compiler = ["black", "jinja2", "protobuf"]
+grpcio = ["grpcio"]
 
 [tool.poe.tasks]
 # Dev workflow tasks

--- a/src/betterproto/grpc/grpcio_server.py
+++ b/src/betterproto/grpc/grpcio_server.py
@@ -1,0 +1,34 @@
+from typing import Dict, TYPE_CHECKING
+from abc import ABC, abstractmethod
+
+if TYPE_CHECKING:
+    import grpc
+
+
+class ServicerBase(ABC):
+    """
+    Base class for async grpcio servers.
+    """
+
+    @property
+    @abstractmethod
+    def __rpc_methods__(self) -> Dict[str, "grpc.RpcMethodHandler"]:
+        ...
+
+    @property
+    @abstractmethod
+    def __proto_path__(self) -> str:
+        ...
+
+
+def register_servicers(server: "grpc.aio.Server", *servicers: ServicerBase):
+    from grpc import method_handlers_generic_handler
+
+    server.add_generic_rpc_handlers(
+        tuple(
+            method_handlers_generic_handler(
+                servicer.__proto_path__, servicer.__rpc_handlers__
+            )
+            for servicer in servicers
+        )
+    )

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -183,6 +183,7 @@ class ProtoContentBase:
 @dataclass
 class Options:
     grpc_kind: str = "grpclib"
+    include_google: bool = False
 
 
 @dataclass

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -181,9 +181,14 @@ class ProtoContentBase:
 
 
 @dataclass
-class PluginRequestCompiler:
+class Options:
+    grpc_kind: str = "grpclib"
 
+
+@dataclass
+class PluginRequestCompiler:
     plugin_request_obj: plugin.CodeGeneratorRequest
+    options: Options
     output_packages: Dict[str, "OutputTemplate"] = field(default_factory=dict)
 
     @property

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -566,6 +566,10 @@ class ServiceCompiler(ProtoContentBase):
         return self.proto_obj.name
 
     @property
+    def proto_path(self) -> str:
+        return self.parent.package + "." + self.proto_name
+
+    @property
     def py_name(self) -> str:
         return pythonize_class_name(self.proto_name)
 

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -21,6 +21,9 @@ from betterproto.grpc.grpclib_server import ServiceBase
 {% if output_file.services and output_file.parent_request.options.grpc_kind == "grpclib" %}
 import grpclib
 {% endif %}
+{% if output_file.services and output_file.parent_request.options.grpc_kind == "grpcio" %}
+import grpc
+{% endif %}
 
 
 {% if output_file.enums %}{% for enum in output_file.enums %}
@@ -240,6 +243,60 @@ class {{ service.py_name }}Base(ServiceBase):
         ),
         {% endfor %}
         }
+
+{% endfor %}
+{% endif %}
+
+{% if output_file.parent_request.options.grpc_kind == "grpcio" %}
+{% for service in output_file.services %}
+class {{ service.py_name }}Base:
+    {% if service.comment %}
+{{ service.comment }}
+
+    {% endif %}
+
+    {% for method in service.methods %}
+    async def {{ method.py_name }}(self
+        {%- if not method.client_streaming -%}
+            , request: "{{ method.py_input_message_type }}"
+        {%- else -%}
+            {# Client streaming: need a request iterator instead #}
+            , request_iterator: AsyncIterator["{{ method.py_input_message_type }}"]
+        {%- endif -%}
+            , context: grpc.aio.ServicerContext
+            ) -> {% if method.server_streaming %}AsyncGenerator["{{ method.py_output_message_type }}", None]{% else %}"{{ method.py_output_message_type }}"{% endif %}:
+        {% if method.comment %}
+{{ method.comment }}
+
+        {% endif %}
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    {% endfor %}
+
+    def register_to_server(self, server: grpc.aio.Server):
+        rpc_method_handlers = {
+        {% for method in service.methods %}
+            "{{ method.proto_name }}":
+            {% if not method.client_streaming and not method.server_streaming %}
+                grpc.unary_unary_rpc_method_handler(
+            {% elif method.client_streaming and method.server_streaming %}
+                grpc.stream_stream_rpc_method_handler(
+            {% elif method.client_streaming %}
+                grpc.stream_unary_rpc_method_handler(
+            {% else %}
+                grpc.unary_stream_rpc_method_handler(
+            {% endif %}
+                    self.{{ method.py_name }},
+                    request_deserializer={{ method.py_input_message_type }}.FromString,
+                    response_serializer={{ method.py_input_message_type }}.SerializeToString,
+                ),
+        {% endfor %}
+        }
+        generic_handler = grpc.method_handlers_generic_handler(
+            "{{ service.proto_path }}", rpc_method_handlers)
+        server.add_generic_rpc_handlers((generic_handler,))
 
 {% endfor %}
 {% endif %}

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -15,8 +15,10 @@ from typing import {% for i in output_file.typing_imports|sort %}{{ i }}{% if no
 {% endif %}
 
 import betterproto
+{% if output_file.parent_request.options.grpc_kind == "grpclib" %}
 from betterproto.grpc.grpclib_server import ServiceBase
-{% if output_file.services %}
+{% endif %}
+{% if output_file.services and output_file.parent_request.options.grpc_kind == "grpclib" %}
 import grpclib
 {% endif %}
 
@@ -68,6 +70,9 @@ class {{ message.py_name }}(betterproto.Message):
 
 
 {% endfor %}
+
+{% if output_file.parent_request.options.grpc_kind == "grpclib" %}
+
 {% for service in output_file.services %}
 class {{ service.py_name }}Stub(betterproto.ServiceStub):
     {% if service.comment %}
@@ -237,6 +242,7 @@ class {{ service.py_name }}Base(ServiceBase):
         }
 
 {% endfor %}
+{% endif %}
 
 {% for i in output_file.imports|sort %}
 {{ i }}

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -23,6 +23,7 @@ import grpclib
 {% endif %}
 {% if output_file.services and output_file.parent_request.options.grpc_kind == "grpcio" %}
 import grpc
+from betterproto.grpc.grpcio_server import ServicerBase
 {% endif %}
 
 
@@ -249,7 +250,7 @@ class {{ service.py_name }}Base(ServiceBase):
 
 {% if output_file.parent_request.options.grpc_kind == "grpcio" %}
 {% for service in output_file.services %}
-class {{ service.py_name }}Base:
+class {{ service.py_name }}Base(ServicerBase):
     {% if service.comment %}
 {{ service.comment }}
 
@@ -275,8 +276,11 @@ class {{ service.py_name }}Base:
 
     {% endfor %}
 
-    def register_to_server(self, server: grpc.aio.Server):
-        rpc_method_handlers = {
+    __proto_path__ = "{{ service.proto_path }}"
+
+    @property
+    def __rpc_methods__(self):
+        return {
         {% for method in service.methods %}
             "{{ method.proto_name }}":
             {% if not method.client_streaming and not method.server_streaming %}
@@ -294,9 +298,6 @@ class {{ service.py_name }}Base:
                 ),
         {% endfor %}
         }
-        generic_handler = grpc.method_handlers_generic_handler(
-            "{{ service.proto_path }}", rpc_method_handlers)
-        server.add_generic_rpc_handlers((generic_handler,))
 
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Fixes #44 

This PR does two thing: it introduces a `grpc-kind` flag that allows specifying which grpc backend we want, if any (none, grpcio, grpclib). It defaults to grpclib for backward compatibility.

Secondly, it adds a new gRPC codegen backend for grpcio. This codegen backend generates base classes that can be registered against an aio grpcio server.

It's fairly early, I literally just whipped this up in a couple hours, but wanted some feedback on the design. I'm not very familiar with python! The base class generated by the new backend looks like this:

```python
class ServiceName(better_proto.grpcio.ServiceBase):
    async def method(
        self, request: ty, context: grpc.aio.ServicerContext
    ) -> ty:
    async def stream_stream_method(
        self, request: AsyncIterator[ty], context: grpc.aio.ServicerContext
    ) -> AsyncGenerator[ty, None]:

    __proto_path__ = ""

    @property
    def __rpc_methods__(self):
```

There are three significant differences compared to the `grpclib` backend:

- The methods take the request object as a single argument. I find this easier to deal with - in my app, I have some fairly large objects going over the network, and getting a bunch of arguments can be bothersome.
- The returned type of server-streaming requests is `AsyncGenerator` instead of `AsyncIterator`. This comes down to a difference between `grpcio` and `grpclib`: `grpcio` expects an `AsyncGenerator` from server-streaming requests, whereas `grpclib` expects an `AsyncIterator`. It might be possible to create a wrapper to unify both backends, but I question how wise this would be. I personally much prefer `grpcio`'s way of returning an `AsyncGenerator` - yielding within the request is much more natural than returning an iterator, especially for stream_stream requests!
- ~~I added a method called `register_to_server`, which registers a given implementation against the grpcio server. Grpcio's official stubs instead have an `add_{{typename}}_to_server` standalone function. I figured making it a method would be cleaner, as it avoids the necessary dance to turn typename lowercase.~~ We now have a `betterproto.grpc.grpcio_server.register_servicers` standalone function to register multiple servicers to a grpcio server.

TODO:
- Make sure the grpcio backend works (I didn't test it yet).
- Rename the grpcio backed to grpcio-aio, to potentially support a sync grpcio support in the future (see #20).