### PR TITLE
Added support for infinite and nan floats/doubles

### DIFF
--- a/tests/inputs/float/float.json
+++ b/tests/inputs/float/float.json
@@ -1,0 +1,9 @@
+{
+    "positive": "Infinity",
+    "negative": "-Infinity",
+    "nan": "NaN",
+    "three": 3.0,
+    "threePointOneFour": 3.14,
+    "negThree": -3.0,
+    "negThreePointOneFour": -3.14
+  }

--- a/tests/inputs/float/float.proto
+++ b/tests/inputs/float/float.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+// Some documentation about the Test message.
+message Test {
+    double positive = 1;
+    double negative = 2;
+    double nan = 3;
+    double three = 4;
+    double three_point_one_four = 5;
+    double neg_three = 6;
+    double neg_three_point_one_four = 7;
+}


### PR DESCRIPTION
Resolves #214.

This pull request adds support for the custom double values defined in the [protobuf spec](https://developers.google.com/protocol-buffers/docs/proto3#json):

- `"Infinity"`
- `"-Infinity"`
- `"Nan"`

Support is added by updates to the `Message.to_dict` and `Message.from_dict` methods, and not via `json.loads`, to ensure that only `double` and `float` fields will have their values casted to `float("inf")`, etc.

Furthermore,

- `Message.__eq__` has been updated to consider NaN values equal, otherwise a message may not be equal to itself
- The `test_message_json` and `test_binary_compatibility` test functions have been updated to use the new `dict_replace_nans ` function that replaces NaN float values with the string `"NaN"` (because `assert float("nan") == float("nan")` always fails).
- Added a `infinite_floats` test to check correctness; this works with the `protobuf` package and fails in the current `master` branch

### Warning

For the sake of clarity, `json.loads(message.to_json())` is not equal to itself in the case that a message contains NaN values.