### PR TITLE
Added docstrings

### DIFF
--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -340,7 +340,7 @@ class MessageCompiler(ProtoContentBase):
         for f in self.fields:
             if f.deprecated:
                 yield f.py_name
-    
+
     @property
     def docstring_params(self) -> str:
         """Docstring parameters
@@ -352,11 +352,19 @@ class MessageCompiler(ProtoContentBase):
         """
         if hasattr(self, "entries"):
             return "\n".join(
-                [entry.docstring for entry in self.entries if hasattr(entry, "docstring")]
+                [
+                    entry.docstring
+                    for entry in self.entries
+                    if hasattr(entry, "docstring")
+                ]
             )
         if hasattr(self, "fields"):
             return "\n".join(
-                [field.docstring for field in self.fields if hasattr(field, "docstring")]
+                [
+                    field.docstring
+                    for field in self.fields
+                    if hasattr(field, "docstring")
+                ]
             )
         raise ValueError("No `field` or `entries` attributes!")
 
@@ -374,8 +382,10 @@ class MessageCompiler(ProtoContentBase):
 
         if not joined:
             return ""
-        
-        heading = "Attributes" if isinstance(self, EnumDefinitionCompiler) else "Parameters"
+
+        heading = (
+            "Attributes" if isinstance(self, EnumDefinitionCompiler) else "Parameters"
+        )
 
         return textwrap.indent(
             f'"""{joined}\n\n{heading}\n----------\n{self.docstring_params}\n"""',
@@ -640,7 +650,9 @@ class EnumDefinitionCompiler(MessageCompiler):
                 name=sanitize_name(entry_proto_value.name),
                 value=entry_proto_value.number,
                 comment=get_comment(
-                    proto_file=self.proto_file, path=self.path + [2, entry_number], comment_out=False
+                    proto_file=self.proto_file,
+                    path=self.path + [2, entry_number],
+                    comment_out=False,
                 ),
             )
             for entry_number, entry_proto_value in enumerate(self.proto_obj.value)
@@ -823,7 +835,7 @@ class ServiceMethodCompiler(ProtoContentBase):
     @property
     def server_streaming(self) -> bool:
         return self.proto_obj.server_streaming
-    
+
     @property
     def docstring(self) -> str:
         intro = get_comment(
@@ -837,9 +849,8 @@ class ServiceMethodCompiler(ProtoContentBase):
 
         if self.py_input_message is None:
             return textwrap.indent(f'"""{intro}"""', pad)
-        
+
         return textwrap.indent(
             f'"""{intro}\n\nParameters\n----------\n{self.py_input_message.docstring_params}\n"""',
             pad,
         )
-            

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -23,14 +23,11 @@ import grpclib
 
 {% if output_file.enums %}{% for enum in output_file.enums %}
 class {{ enum.py_name }}(betterproto.Enum):
-    {% if enum.comment %}
-{{ enum.comment }}
+    {% if enum.docstring %}
+{{ enum.docstring }}
 
     {% endif %}
     {% for entry in enum.entries %}
-        {% if entry.comment %}
-{{ entry.comment }}
-        {% endif %}
     {{ entry.name }} = {{ entry.value }}
     {% endfor %}
 
@@ -40,14 +37,10 @@ class {{ enum.py_name }}(betterproto.Enum):
 {% for message in output_file.messages %}
 @dataclass(eq=False, repr=False)
 class {{ message.py_name }}(betterproto.Message):
-    {% if message.comment %}
-{{ message.comment }}
-
+    {% if message.docstring %}
+{{ message.docstring }}
     {% endif %}
     {% for field in message.fields %}
-        {% if field.comment %}
-{{ field.comment }}
-        {% endif %}
     {{ field.get_field_string() }}
     {% endfor %}
     {% if not message.fields %}
@@ -97,9 +90,8 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
             , request_iterator: Union[AsyncIterable["{{ method.py_input_message_type }}"], Iterable["{{ method.py_input_message_type }}"]]
         {%- endif -%}
             ) -> {% if method.server_streaming %}AsyncIterator["{{ method.py_output_message_type }}"]{% else %}"{{ method.py_output_message_type }}"{% endif %}:
-        {% if method.comment %}
-{{ method.comment }}
-
+        {% if method.docstring %}
+{{ method.docstring }}
         {% endif %}
         {%- for py_name, zero in method.mutable_default_args.items() %}
         {{ py_name }} = {{ py_name }} or {{ zero }}
@@ -180,8 +172,8 @@ class {{ service.py_name }}Base(ServiceBase):
             , request_iterator: AsyncIterator["{{ method.py_input_message_type }}"]
         {%- endif -%}
             ) -> {% if method.server_streaming %}AsyncIterator["{{ method.py_output_message_type }}"]{% else %}"{{ method.py_output_message_type }}"{% endif %}:
-        {% if method.comment %}
-{{ method.comment }}
+        {% if method.docstring %}
+{{ method.docstring }}
 
         {% endif %}
         raise grpclib.GRPCError(grpclib.const.Status.UNIMPLEMENTED)

--- a/tests/inputs/docstrings/docstrings.proto
+++ b/tests/inputs/docstrings/docstrings.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package echo;
-
 enum Casing { // Message casing
   UNCHANGED = 0; // Don't change the message
   LOWERCASE = 1; // Convert to lowercase
@@ -9,18 +7,10 @@ enum Casing { // Message casing
   TITLECASE = 3; // Convert to titlecase
 }
 
-message EchoRequest { // A request to the server
+message Test { // A request to the server
   // String to echo
   string value = 1;
   // Number of extra times to echo
   uint32 extra_times = 2;
   Casing casing = 3; // Message case
-}
-
-message EchoResponse { // A response message
-  repeated string values = 1; // The echoed strings
-}
-
-service Echo { // The Echo service
-  rpc Echo(EchoRequest) returns (EchoResponse); // Non-streaming requests
 }

--- a/tests/inputs/docstrings/docstrings.proto
+++ b/tests/inputs/docstrings/docstrings.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package echo;
+
+enum Casing { // Message casing
+  UNCHANGED = 0; // Don't change the message
+  LOWERCASE = 1; // Convert to lowercase
+  UPPERCASE = 2; // Convert to uppercase
+  TITLECASE = 3; // Convert to titlecase
+}
+
+message EchoRequest { // A request to the server
+  // String to echo
+  string value = 1;
+  // Number of extra times to echo
+  uint32 extra_times = 2;
+  Casing casing = 3; // Message case
+}
+
+message EchoResponse { // A response message
+  repeated string values = 1; // The echoed strings
+}
+
+service Echo { // The Echo service
+  rpc Echo(EchoRequest) returns (EchoResponse); // Non-streaming requests
+}


### PR DESCRIPTION
The first commit, [39b8f6f](https://github.com/danielgtaylor/python-betterproto/commit/39b8f6fcbafe4a85f4c191e9a7d5211c3d2042a1), resolves #209 by keeping track of the input filename for each object (though it will not deal with extended messages in different source files). Everything else is somewhat more opinionated—it adds NumPy-style docstrings in place of the existing comments.

Take this example `.proto` source file:

```protobuf
syntax = "proto3";

enum Casing { // Message casing
  UNCHANGED = 0; // Don't change the message
  LOWERCASE = 1; // Convert to lowercase
  UPPERCASE = 2; // Convert to uppercase
  TITLECASE = 3; // Convert to titlecase
}

message Test { // A request to the server
  // String to echo
  string value = 1;
  // Number of extra times to echo
  uint32 extra_times = 2;
  Casing casing = 3; // Message case
}
```

Currently, the only comment captured from this source are the leading comments in `EchoRequest`.

```python
@dataclass(eq=False, repr=False)
class Test(betterproto.Message):
    # String to echo
    value: str = betterproto.string_field(1)
    # Number of extra times to echo
    extra_times: int = betterproto.uint32_field(2)
    casing: "Casing" = betterproto.enum_field(3)

    def __post_init__(self) -> None:
        super().__post_init__()
```

Commits [d608d80](https://github.com/danielgtaylor/python-betterproto/commit/d608d80b4c5e3decaf9f07ee19f3cfc688b1284d) and [/26a6d8e0](https://github.com/danielgtaylor/python-betterproto/commit/26a6d8e01d1aef9f367164f3be0c1141d0c17255) replace the existing `comment` properties of the `ProtoContentBase` class and its subclasses with `docstring` properties specific to their type. For instance, the `docstring ` property of a `FieldCompiler` includes its name and annotation. `get_comment` has also been updated to include trailing comments. `MessageCompiler` and its subclasses now have NumPy-style docstrings, and the output from the above proto source file now looks like this:

```python
class Casing(betterproto.Enum):
    """Message casing

    Attributes
    ----------
    UNCHANGED : int = 0
        Don't change the message
    LOWERCASE : int = 1
        Convert to lowercase
    UPPERCASE : int = 2
        Convert to uppercase
    TITLECASE : int = 3
        Convert to titlecase
    """

    UNCHANGED = 0
    LOWERCASE = 1
    UPPERCASE = 2
    TITLECASE = 3


@dataclass(eq=False, repr=False)
class Test(betterproto.Message):
    """A request to the server

    Parameters
    ----------
    value : str
        String to echo
    extra_times : int
        Number of extra times to echo
    casing : Casing
        Message case
    """

    value: str = betterproto.string_field(1)
    extra_times: int = betterproto.uint32_field(2)
    casing: "Casing" = betterproto.enum_field(3)

    def __post_init__(self) -> None:
        super().__post_init__()
```

These output docstrings can then be used by e.g. Sphinx autodoc with napoleon to generate Python package documentation directly from the .proto source files