### PR TITLE
Allow empty services.

### DIFF
--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -73,6 +73,8 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
     {% if service.comment %}
 {{ service.comment }}
 
+    {% elif not service.methods %}
+    pass
     {% endif %}
     {% for method in service.methods %}
     async def {{ method.py_name }}(self

--- a/tests/inputs/config.py
+++ b/tests/inputs/config.py
@@ -18,4 +18,5 @@ services = {
     "googletypes_service_returns_empty",
     "googletypes_service_returns_googletype",
     "example_service",
+    "empty_service",
 }

--- a/tests/inputs/empty_service/empty_service.proto
+++ b/tests/inputs/empty_service/empty_service.proto
@@ -1,0 +1,7 @@
+/* Empty service without comments */
+syntax = "proto3";
+
+package empty_service;
+
+service Test {
+}


### PR DESCRIPTION
Allow empty service without comment to be compiled.

While you may think that this issue can be easily circumvented by adding comments, it was very hard to do so with issue #221 present, where it deletes comments somewhere in the codebase.

Fixes issue #220