### PR TITLE
Fix compilation of fields named 'bytes' or 'str'

### DIFF
--- a/src/betterproto/casing.py
+++ b/src/betterproto/casing.py
@@ -132,7 +132,15 @@ def lowercase_first(value: str) -> str:
     """
     return value[0:1].lower() + value[1:]
 
+def is_keyword(value: str) -> bool:
+    if keyword.iskeyword(value):
+        return True
+
+    if value == "bytes":
+        return True
+
+    return False
 
 def sanitize_name(value: str) -> str:
     # https://www.python.org/dev/peps/pep-0008/#descriptive-naming-styles
-    return f"{value}_" if keyword.iskeyword(value) else value
+    return f"{value}_" if is_keyword(value) else value

--- a/src/betterproto/casing.py
+++ b/src/betterproto/casing.py
@@ -133,11 +133,11 @@ def lowercase_first(value: str) -> str:
     return value[0:1].lower() + value[1:]
 
 
-def is_keyword(value: str) -> bool:
+def is_reserved_name(value: str) -> bool:
     if keyword.iskeyword(value):
         return True
 
-    if value == "bytes":
+    if value in ("bytes", "str"):
         return True
 
     return False
@@ -145,4 +145,4 @@ def is_keyword(value: str) -> bool:
 
 def sanitize_name(value: str) -> str:
     # https://www.python.org/dev/peps/pep-0008/#descriptive-naming-styles
-    return f"{value}_" if is_keyword(value) else value
+    return f"{value}_" if is_reserved_name(value) else value

--- a/src/betterproto/casing.py
+++ b/src/betterproto/casing.py
@@ -132,6 +132,7 @@ def lowercase_first(value: str) -> str:
     """
     return value[0:1].lower() + value[1:]
 
+
 def is_keyword(value: str) -> bool:
     if keyword.iskeyword(value):
         return True
@@ -140,6 +141,7 @@ def is_keyword(value: str) -> bool:
         return True
 
     return False
+
 
 def sanitize_name(value: str) -> str:
     # https://www.python.org/dev/peps/pep-0008/#descriptive-naming-styles

--- a/tests/inputs/config.py
+++ b/tests/inputs/config.py
@@ -3,7 +3,6 @@
 xfail = {
     "oneof_enum",  # 63
     "namespace_keywords",  # 70
-    "namespace_builtin_types",  # 53
     "googletypes_struct",  # 9
     "googletypes_value",  # 9
     "import_capitalized_package",


### PR DESCRIPTION
This PR replaces #193 (because I didn't have write access).

I enabled the previously xfail marked namespace_builtin_types test case and tweaked the code from @SpencerSharkey to fully cover it.