### PR TITLE
Micro-optimization: use tuples instead of lists for conditions

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -307,16 +307,16 @@ def encode_varint(value: int) -> bytes:
 
 def _preprocess_single(proto_type: str, wraps: str, value: Any) -> bytes:
     """Adjusts values before serialization."""
-    if proto_type in [
+    if proto_type in (
         TYPE_ENUM,
         TYPE_BOOL,
         TYPE_INT32,
         TYPE_INT64,
         TYPE_UINT32,
         TYPE_UINT64,
-    ]:
+    ):
         return encode_varint(value)
-    elif proto_type in [TYPE_SINT32, TYPE_SINT64]:
+    elif proto_type in (TYPE_SINT32, TYPE_SINT64):
         # Handle zig-zag encoding.
         return encode_varint(value << 1 if value >= 0 else (value << 1) ^ (~0))
     elif proto_type in FIXED_TYPES:
@@ -840,18 +840,18 @@ class Message(ABC):
     ) -> Any:
         """Adjusts values after parsing."""
         if wire_type == WIRE_VARINT:
-            if meta.proto_type in [TYPE_INT32, TYPE_INT64]:
+            if meta.proto_type in (TYPE_INT32, TYPE_INT64):
                 bits = int(meta.proto_type[3:])
                 value = value & ((1 << bits) - 1)
                 signbit = 1 << (bits - 1)
                 value = int((value ^ signbit) - signbit)
-            elif meta.proto_type in [TYPE_SINT32, TYPE_SINT64]:
+            elif meta.proto_type in (TYPE_SINT32, TYPE_SINT64):
                 # Undo zig-zag encoding
                 value = (value >> 1) ^ (-(value & 1))
             elif meta.proto_type == TYPE_BOOL:
                 # Booleans use a varint encoding, so convert it to true/false.
                 value = value > 0
-        elif wire_type in [WIRE_FIXED_32, WIRE_FIXED_64]:
+        elif wire_type in (WIRE_FIXED_32, WIRE_FIXED_64):
             fmt = _pack_fmt(meta.proto_type)
             value = struct.unpack(fmt, value)[0]
         elif wire_type == WIRE_LEN_DELIM:
@@ -915,10 +915,10 @@ class Message(ABC):
                 pos = 0
                 value = []
                 while pos < len(parsed.value):
-                    if meta.proto_type in [TYPE_FLOAT, TYPE_FIXED32, TYPE_SFIXED32]:
+                    if meta.proto_type in (TYPE_FLOAT, TYPE_FIXED32, TYPE_SFIXED32):
                         decoded, pos = parsed.value[pos : pos + 4], pos + 4
                         wire_type = WIRE_FIXED_32
-                    elif meta.proto_type in [TYPE_DOUBLE, TYPE_FIXED64, TYPE_SFIXED64]:
+                    elif meta.proto_type in (TYPE_DOUBLE, TYPE_FIXED64, TYPE_SFIXED64):
                         decoded, pos = parsed.value[pos : pos + 8], pos + 8
                         wire_type = WIRE_FIXED_64
                     else:
@@ -1264,7 +1264,7 @@ class _Duration(Duration):
     def delta_to_json(delta: timedelta) -> str:
         parts = str(delta.total_seconds()).split(".")
         if len(parts) > 1:
-            while len(parts[1]) not in [3, 6, 9]:
+            while len(parts[1]) not in (3, 6, 9):
                 parts[1] = f"{parts[1]}0"
         return f"{'.'.join(parts)}s"
 


### PR DESCRIPTION
This should give a small speed boost to some critical code paths.

The benchmark suite says it's not worse... (though it's not very sensitive).

According to some internets, tuple creation in these situations is ~5x faster than list creation: e.g. http://zwmiller.com/blogs/python_data_structure_speed.html

```
       before           after         ratio
     [7c5ee47e]       [58d5aa2f]
     <master>         <use_tuples>
      1.62±0.04μs      1.61±0.08μs     0.99  benchmarks.BenchMessage.time_attribute_access
       8.60±0.3μs       8.71±0.2μs     1.01  benchmarks.BenchMessage.time_attribute_setting
       14.4±0.7μs       13.8±0.3μs     0.96  benchmarks.BenchMessage.time_init_with_values
       14.0±0.5μs       13.3±0.5μs     0.95  benchmarks.BenchMessage.time_instantiation
         370±10μs         344±10μs     0.93  benchmarks.BenchMessage.time_overhead
       22.7±0.3μs         21.1±1μs     0.93  benchmarks.BenchMessage.time_serialize
              424              424     1.00  benchmarks.MemSuite.mem_instance
```