### PR TITLE
add hooks for accessing the stream/metadata

### DIFF
--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -43,6 +43,27 @@ You cannot check if a scalar was sent on the wire.
     True
 
 
+Accessing the Stream/Metadata
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you need access to the ``grpclib.server.Stream`` object, either to access the call metadata
+or for other reasons, you can implement ``<method>__with_stream`` instead:
+
+.. code-block:: python
+
+    # this method also receives the unspread request object
+    async def example_unary_unary__with_stream(
+        self, stream: grpclib.server.Stream, request: "ExampleRequest"
+    ) -> "ExampleResponse":
+        # metadata is a MultiDict
+        auth = stream.metadata.get("authorization")
+        # grpclib.events.listen is probably a better way to check auth
+        await check_auth(auth)
+
+        return await get_response(request)
+
+Note the double underscore in the method name. This is slightly ugly but should avoid name collisions.
+
 One-of Support
 ~~~~~~~~~~~~~~
 

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -194,6 +194,32 @@ class {{ service.py_name }}Base(ServiceBase):
     async def __rpc_{{ method.py_name }}(self, stream: grpclib.server.Stream) -> None:
         {% if not method.client_streaming %}
         request = await stream.recv_message()
+        {% else %}
+        request = stream.__aiter__()
+        {% endif %}
+
+
+        {% if not method.server_streaming %}
+        response = await self.{{ method.py_name }}__with_stream(stream, request)
+        await stream.send_message(response)
+        {% else %}
+        response = self.{{ method.py_name }}__with_stream(stream, request)
+        if isinstance(response, AsyncIterable):
+            async for response_message in response:
+                await stream.send_message(response_message)
+        else:
+            response.close()
+        {% endif %}
+
+    async def {{ method.py_name }}__with_stream(self,
+                                                stream: grpclib.server.Stream,
+                                                request: {% if method.server_streaming %}AsyncIterator["{{ method.py_input_message_type }}"]{% else %}"{{ method.py_input_message_type }}"{% endif %}
+            ) -> {% if method.server_streaming %}AsyncIterator["{{ method.py_output_message_type }}"]{% else %}"{{ method.py_output_message_type }}"{% endif %}:
+        {% if method.comment %}
+{{ method.comment }}
+
+        {% endif %}
+        {% if not method.client_streaming %}
 
         request_kwargs = {
         {% for field in method.py_input_message.fields %}
@@ -202,18 +228,13 @@ class {{ service.py_name }}Base(ServiceBase):
         }
 
         {% else %}
-        request_kwargs = {"request_iterator": stream.__aiter__()}
+        request_kwargs = {"request_iterator": request}
         {% endif %}
 
-        {% if not method.server_streaming %}
-        response = await self.{{ method.py_name }}(**request_kwargs)
-        await stream.send_message(response)
+        {% if method.server_streaming %}
+        return self.{{ method.py_name }}(**request_kwargs)
         {% else %}
-        await self._call_rpc_handler_server_stream(
-            self.{{ method.py_name }},
-            stream,
-            request_kwargs,
-        )
+        return await self.{{ method.py_name }}(**request_kwargs)
         {% endif %}
 
     {% endfor %}


### PR DESCRIPTION
This is just an extra layer in the generated code for accessing the underlying stream to read metadata, etc. Users can implement this instead of the method without suffix for a slightly lower level experience.

The stack becomes:
`__rpc_<method>` handle recv & send -> `<method>__with_stream` default implementation spreads the request -> `<method>` same semantics