### PR TITLE
feature/add-benchmark-case-for-deserialize-and-large

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,12 +1,37 @@
 import betterproto
 from dataclasses import dataclass
 
+from typing import List
+
 
 @dataclass
 class TestMessage(betterproto.Message):
     foo: int = betterproto.uint32_field(0)
     bar: str = betterproto.string_field(1)
     baz: float = betterproto.float_field(2)
+
+
+@dataclass
+class TestNestedChildMessage(betterproto.Message):
+    str_key: str = betterproto.string_field(0)
+    bytes_key: bytes = betterproto.bytes_field(1)
+    bool_key: bool = betterproto.bool_field(2)
+    float_key: float = betterproto.float_field(3)
+    int_key: int = betterproto.uint64_field(4)
+
+
+@dataclass
+class TestNestedMessage(betterproto.Message):
+    foo: TestNestedChildMessage = betterproto.message_field(0)
+    bar: TestNestedChildMessage = betterproto.message_field(1)
+    baz: TestNestedChildMessage = betterproto.message_field(2)
+
+
+@dataclass
+class TestRepeatedMessage(betterproto.Message):
+    foo_repeat: List[str] = betterproto.string_field(0)
+    bar_repeat: List[int] = betterproto.int64_field(1)
+    baz_repeat: List[bool] = betterproto.bool_field(2)
 
 
 class BenchMessage:
@@ -16,6 +41,30 @@ class BenchMessage:
         self.cls = TestMessage
         self.instance = TestMessage()
         self.instance_filled = TestMessage(0, "test", 0.0)
+        self.instance_filled_bytes = bytes(self.instance_filled)
+        self.instance_filled_nested = TestNestedMessage(
+            TestNestedChildMessage("foo", bytearray(b"test1"), True, 0.1234, 500),
+            TestNestedChildMessage("bar", bytearray(b"test2"), True, 3.1415, -302),
+            TestNestedChildMessage("baz", bytearray(b"test3"), False, 1e5, 300),
+        )
+        self.instance_filled_nested_bytes = bytes(self.instance_filled_nested)
+        self.instance_filled_repeated = TestRepeatedMessage(
+            [
+                "test1",
+                "test2",
+                "test3",
+                "test4",
+                "test5",
+                "test6",
+                "test7",
+                "test8",
+                "test9",
+                "test10",
+            ],
+            [2, -100, 0, 500000, 600, -425678, 1000000000, -300, 1, -694214214466],
+            [True, False, False, False, True, True, False, True, False, False],
+        )
+        self.instance_filled_repeated_bytes = bytes(self.instance_filled_repeated)
 
     def time_overhead(self):
         """Overhead in class definition."""
@@ -49,6 +98,26 @@ class BenchMessage:
     def time_serialize(self):
         """Time serializing a message to wire."""
         bytes(self.instance_filled)
+
+    def time_deserialize(self):
+        """Time deserialize a message."""
+        TestMessage().parse(self.instance_filled_bytes)
+
+    def time_serialize_nested(self):
+        """Time serializing a nested message to wire."""
+        bytes(self.instance_filled_nested)
+
+    def time_deserialize_nested(self):
+        """Time deserialize a nested message."""
+        TestNestedMessage().parse(self.instance_filled_nested_bytes)
+
+    def time_serialize_repeated(self):
+        """Time serializing a repeated message to wire."""
+        bytes(self.instance_filled_repeated)
+
+    def time_deserialize_repeated(self):
+        """Time deserialize a repeated message."""
+        TestRepeatedMessage().parse(self.instance_filled_repeated_bytes)
 
 
 class MemSuite:


### PR DESCRIPTION
## Background

When attempting to parse the List[bytes] type as betterproto, approx. 1,000 elements or more. 500ms is required.
Our service needs to parse more than 1,000 unit bytes using betterproto, and it was determined that it would be a problem for the business to require more than 500ms of resources for each request, so I decided to improve the parse function of betterproto.

Therefore, it is necessary to know the baseline for deserialize performance improvement before working on improvement proposals in subsequent PR. In betterproto, we added benchmark cases for three message cases (simple message, nested message, repeated message) and worked on this PR. First, we want to merge them to get the baseline.

In the future, I will proceed with the following attempts.

- Analysis and improvement of profiling and time complexity for `parse` method
- If the above method determines that work improvement is impossible due to the influence of the betterproto lifecycle, proceed as follows.
    - Fork betterproto and parse itself through CDLL Extension in C language, and perform computation-intensive work in C native-level by extracting .so and .dll (I don't know if merger is possible, the impact on multi-platform increases. )
- We will also review whether the parse method can direct-dump struct memory, and look at issues and PRs for discussions in advance.

## Features

- Add benchmark cases as follows
    - time_deserialize
    - time_serialize_nested
    - time_deserialize_nested
    - time_serialize_repeated
    - time_deserialize_repeated

- How to test

```plaintext
<spec>
- Darwin 19.6.0
- x86_64
- Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
- num cores: 16
- 32GB mem
```

```bash
asv run
· Creating environments
· Discovering benchmarks
· Running 12 total benchmarks (1 commits * 1 environments * 12 benchmarks)
[  0.00%] · For python-betterproto commit 02e41afd <v2.0.0b3>:
[  0.00%] ·· Benchmarking virtualenv-py3.9
[  4.17%] ··· Running (benchmarks.BenchMessage.time_attribute_access--)...........
[ 54.17%] ··· benchmarks.BenchMessage.time_attribute_access                          879±70ns
[ 58.33%] ··· benchmarks.BenchMessage.time_attribute_setting                       4.82±0.2μs
[ 62.50%] ··· benchmarks.BenchMessage.time_deserialize                             17.1±0.2μs
[ 66.67%] ··· benchmarks.BenchMessage.time_deserialize_nested                         217±4μs
[ 70.83%] ··· benchmarks.BenchMessage.time_deserialize_repeated                      99.3±2μs
[ 75.00%] ··· benchmarks.BenchMessage.time_init_with_values                        7.71±0.3μs
[ 79.17%] ··· benchmarks.BenchMessage.time_instantiation                           7.57±0.2μs
[ 83.33%] ··· benchmarks.BenchMessage.time_overhead                                   319±8μs
[ 87.50%] ··· benchmarks.BenchMessage.time_serialize                               10.4±0.3μs
[ 91.67%] ··· benchmarks.BenchMessage.time_serialize_nested                           172±2μs
[ 95.83%] ··· benchmarks.BenchMessage.time_serialize_repeated                        50.0±2μs
[100.00%] ··· benchmarks.MemSuite.mem_instance                                            408
```