### PR TITLE
error message when None appears in a repeated value [was] not helpful

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -739,6 +739,8 @@ class Message(ABC):
                     output += _serialize_single(meta.number, TYPE_BYTES, buf)
                 else:
                     for item in value:
+                        if item is None:
+                            raise ValueError(f"None value in list field {field_name} of {self}")
                         output += (
                             _serialize_single(
                                 meta.number,

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -333,6 +333,18 @@ def test_oneof_default_value_set_causes_writes_wire():
     )
 
 
+def test_none_in_list_error_message():
+    from tests.output_betterproto.empty_repeated import Test as EmptyRepeated
+
+    # this is an error, tell me where the problem is
+    try:
+        print(bytes(EmptyRepeated(
+            msg=[None]
+        )))
+    except ValueError as e:
+        assert "msg" in str(e)
+
+
 def test_recursive_message():
     from tests.output_betterproto.recursivemessage import Test as RecursiveMessage
 


### PR DESCRIPTION
If a `None` slips into a list to be serialized, the resulting error message doesn't provide any information about where the problem was. This preemptively detects `None` values in a collection and raises a message that should make it easy to track down.