### PR TITLE
fix: Map field edge-case

### DIFF
--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -339,6 +339,9 @@ def is_map(
 ) -> bool:
     """True if proto_field_obj is a map, otherwise False."""
     if proto_field_obj.type == FieldDescriptorProtoType.TYPE_MESSAGE:
+        if not hasattr(parent_message, "nested_type"):
+            return False
+
         # This might be a map...
         message_type = proto_field_obj.type_name.split(".").pop().lower()
         map_entry = f"{proto_field_obj.name.replace('_', '').lower()}entry"

--- a/tests/inputs/entry/entry.proto
+++ b/tests/inputs/entry/entry.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+// This is a minimal example of a repeated message field that caused issues when
+// checking whether a message is a map.
+//
+// During the check wheter a field is a "map", the string "entry" is added to
+// the field name, checked against the type name and then further checks are
+// made against the nested type of a parent message. In this edge-case, the
+// first check would pass even though it shouldn't and that would cause an
+// error because the parent type does not have a "nested_type" attribute.
+
+message Test {
+    repeated ExportEntry export = 1;
+}
+
+message ExportEntry {
+    string name = 1;
+}

--- a/tests/inputs/entry/entry.proto
+++ b/tests/inputs/entry/entry.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package entry;
+
 // This is a minimal example of a repeated message field that caused issues when
 // checking whether a message is a map.
 //


### PR DESCRIPTION
Hello! I've hit upon this weird edge-case when using `betterproto` in our project.
It took me a while to find the cause (especially realizing that the field name caused the problem)
but the solution is quite simple. I've tried to find a better way to check for the map field type
but was unable to find one (I'm not very familiar with the protobuf internals).