### PR TITLE
Import ServiceBase only when some services are defined

### DIFF
--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -15,8 +15,8 @@ from typing import {% for i in output_file.typing_imports|sort %}{{ i }}{% if no
 {% endif %}
 
 import betterproto
-from betterproto.grpc.grpclib_server import ServiceBase
 {% if output_file.services %}
+from betterproto.grpc.grpclib_server import ServiceBase
 import grpclib
 {% endif %}
 


### PR DESCRIPTION
Just noticed that import of `ServiceBase` is not required when no services are defined