### PR TITLE
map enum int's into python enums (#157)

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -871,7 +871,10 @@ class Message(ABC):
             elif meta.proto_type == TYPE_ENUM:
                 # Convert enum ints to python enum instances
                 cls = self._betterproto.cls_by_field[field_name]
-                value = cls(value)
+                try:
+                    value = cls(value)
+                except ValueError:
+                    pass  # the received value does not exist in the enum so we have to pass it as raw int
         elif wire_type in (WIRE_FIXED_32, WIRE_FIXED_64):
             fmt = _pack_fmt(meta.proto_type)
             value = struct.unpack(fmt, value)[0]

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -835,8 +835,15 @@ class Message(ABC):
             else:
                 return t
         elif issubclass(t, Enum):
-            cls = cls._cls_for(field)
-            return lambda: cls(0)  # Enums always default to zero.
+            # Enums always default to zero.
+            def default_enum():
+                try:
+                    # try to create a python enum instance
+                    return t(0)
+                except ValueError:
+                    return 0  # if that does not work fallback to int
+
+            return default_enum
         elif t is datetime:
             # Offsets are relative to 1970-01-01T00:00:00Z
             return datetime_default_gen

--- a/tests/inputs/enum/test_enum.py
+++ b/tests/inputs/enum/test_enum.py
@@ -82,3 +82,23 @@ def test_repeated_enum_with_non_list_iterables_to_dict():
         yield Choice.THREE
 
     assert Test(choices=enum_generator()).to_dict()["choices"] == ["ONE", "THREE"]
+
+
+def test_enum_mapped_on_parse():
+    # test default value
+    b = Test().parse(bytes(Test()))
+    assert b.choice.name == Choice.ZERO.name
+    assert b.choices == []
+
+    # test non default value
+    a = Test().parse(bytes(Test(choice=Choice.ONE)))
+    assert a.choice.name == Choice.ONE.name
+    assert b.choices == []
+
+    # test repeated
+    c = Test().parse(bytes(Test(choices=[Choice.THREE, Choice.FOUR])))
+    assert c.choices[0].name == Choice.THREE.name
+    assert c.choices[1].name == Choice.FOUR.name
+
+    # bonus: defaults after empty init are also mapped
+    assert Test().choice.name == Choice.ZERO.name


### PR DESCRIPTION
This maps deserialized enum integers into real python enum instances.

Closes #157, #169 