### PR TITLE
Fix compilation of fields with name identical to their type

### DIFF
--- a/src/betterproto/casing.py
+++ b/src/betterproto/casing.py
@@ -133,16 +133,6 @@ def lowercase_first(value: str) -> str:
     return value[0:1].lower() + value[1:]
 
 
-def is_reserved_name(value: str) -> bool:
-    if keyword.iskeyword(value):
-        return True
-
-    if value in ("bytes", "str"):
-        return True
-
-    return False
-
-
 def sanitize_name(value: str) -> str:
     # https://www.python.org/dev/peps/pep-0008/#descriptive-naming-styles
-    return f"{value}_" if is_reserved_name(value) else value
+    return f"{value}_" if keyword.iskeyword(value) else value

--- a/tests/inputs/config.py
+++ b/tests/inputs/config.py
@@ -2,6 +2,7 @@
 # Remove from list when fixed.
 xfail = {
     "namespace_keywords",  # 70
+    "namespace_builtin_types",  # 53
     "googletypes_struct",  # 9
     "googletypes_value",  # 9
     "import_capitalized_package",

--- a/tests/inputs/config.py
+++ b/tests/inputs/config.py
@@ -2,7 +2,6 @@
 # Remove from list when fixed.
 xfail = {
     "namespace_keywords",  # 70
-    "namespace_builtin_types",  # 53
     "googletypes_struct",  # 9
     "googletypes_value",  # 9
     "import_capitalized_package",

--- a/tests/inputs/field_name_identical_to_type/field_name_identical_to_type.json
+++ b/tests/inputs/field_name_identical_to_type/field_name_identical_to_type.json
@@ -1,0 +1,7 @@
+{
+    "int": 26,
+    "float": 26.0,
+    "str": "value-for-str",
+    "bytes": "001a",
+    "bool": true
+}

--- a/tests/inputs/field_name_identical_to_type/field_name_identical_to_type.proto
+++ b/tests/inputs/field_name_identical_to_type/field_name_identical_to_type.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+// Tests that messages may contain fields with names that are identical to their python types (PR #294)
+
+message Test {
+    int32 int = 1;
+    float float = 2;
+    string str = 3;
+    bytes bytes = 4;
+    bool bool = 5;
+}


### PR DESCRIPTION
Defining a dataclass with a field that its name is identical to its type name, and is initialized as a `field` produces `RecursionError`:
```
from dataclasses import dataclass, field
@dataclass
class Foo:
    bool: bool = field()
```
This PR suggests a solution to the problem by using built-in types from the builtins package, so the above code will be changed to:
 ```
from dataclasses import dataclass, field
import builtins
@dataclass
class Foo:
    bool: builtints.bool = field()
```

This PR also reverts #226 because it is solving a more general problem.