### PR TITLE
Ensure any fields that could intersect with Message are renamed

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -609,7 +609,12 @@ class Message(ABC):
             Calls :meth:`__bool__`.
     """
 
-    _serialized_on_wire: bool
+    serialized_on_wire: bool
+    """
+    If this message was or should be serialized on the wire. This can be used to detect
+    presence (e.g. optional wrapper message) and is used internally during
+    parsing/serialization.
+    """
     _unknown_fields: bytes
     _group_current: Dict[str, str]
 
@@ -634,7 +639,7 @@ class Message(ABC):
                     group_current[meta.group] = field_name
 
         # Now that all the defaults are set, reset it!
-        self.__dict__["_serialized_on_wire"] = not all_sentinel
+        self.__dict__["serialized_on_wire"] = not all_sentinel
         self.__dict__["_unknown_fields"] = b""
         self.__dict__["_group_current"] = group_current
 
@@ -694,9 +699,9 @@ class Message(ABC):
         return value
 
     def __setattr__(self, attr: str, value: Any) -> None:
-        if attr != "_serialized_on_wire":
+        if attr != "serialized_on_wire":
             # Track when a field has been set.
-            self.__dict__["_serialized_on_wire"] = True
+            self.__dict__["serialized_on_wire"] = True
 
         if hasattr(self, "_group_current"):  # __post_init__ had already run
             if attr in self._betterproto.oneof_group_by_field:
@@ -756,7 +761,7 @@ class Message(ABC):
 
             # Empty messages can still be sent on the wire if they were
             # set (or received empty).
-            serialize_empty = isinstance(value, Message) and value._serialized_on_wire
+            serialize_empty = isinstance(value, Message) and value.serialized_on_wire
 
             include_default_value_for_oneof = self._include_default_value_for_oneof(
                 field_name=field_name, meta=meta
@@ -924,7 +929,7 @@ class Message(ABC):
                     value = _get_wrapper(meta.wraps)().parse(value).value
                 else:
                     value = cls().parse(value)
-                    value._serialized_on_wire = True
+                    value.serialized_on_wire = True
             elif meta.proto_type == TYPE_MAP:
                 value = self._betterproto.cls_by_field[field_name]().parse(value)
 
@@ -953,7 +958,7 @@ class Message(ABC):
             The initialized message.
         """
         # Got some data over the wire
-        self._serialized_on_wire = True
+        self.serialized_on_wire = True
         proto_meta = self._betterproto
         for parsed in parse_fields(data):
             field_name = proto_meta.field_name_by_number.get(parsed.number)
@@ -1089,7 +1094,7 @@ class Message(ABC):
                     if include_default_values:
                         output[cased_name] = value
                 elif (
-                    value._serialized_on_wire
+                    value.serialized_on_wire
                     or include_default_values
                     or self._include_default_value_for_oneof(
                         field_name=field_name, meta=meta
@@ -1170,7 +1175,7 @@ class Message(ABC):
         :class:`Message`
             The initialized message.
         """
-        self._serialized_on_wire = True
+        self.serialized_on_wire = True
         for key in value:
             field_name = safe_snake_case(key)
             meta = self._betterproto.meta_by_field_name.get(field_name)
@@ -1280,34 +1285,19 @@ class Message(ABC):
         """
         return self.from_dict(json.loads(value))
 
+    def which_one_of(self, group_name: str) -> Tuple[str, Optional[Any]]:
+        """
+        Return the name and value of a message's one-of field group.
 
-def serialized_on_wire(message: Message) -> bool:
-    """
-    If this message was or should be serialized on the wire. This can be used to detect
-    presence (e.g. optional wrapper message) and is used internally during
-    parsing/serialization.
-
-    Returns
-    --------
-    :class:`bool`
-        Whether this message was or should be serialized on the wire.
-    """
-    return message._serialized_on_wire
-
-
-def which_one_of(message: Message, group_name: str) -> Tuple[str, Optional[Any]]:
-    """
-    Return the name and value of a message's one-of field group.
-
-    Returns
-    --------
-    Tuple[:class:`str`, Any]
-        The field name and the value for that field.
-    """
-    field_name = message._group_current.get(group_name)
-    if not field_name:
-        return "", None
-    return field_name, getattr(message, field_name)
+        Returns
+        --------
+        Tuple[:class:`str`, Any]
+            The field name and the value for that field.
+        """
+        field_name = self._group_current.get(group_name)
+        if not field_name:
+            return "", None
+        return field_name, getattr(self, field_name)
 
 
 # Circular import workaround: google.protobuf depends on base classes defined above.

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -501,7 +501,11 @@ class FieldCompiler(MessageCompiler):
     @property
     def py_name(self) -> str:
         """Pythonized name."""
-        return pythonize_field_name(self.proto_name)
+        unsafe_name = pythonize_field_name(self.proto_name)
+        # rename fields in case they clash with things defined in Message
+        if unsafe_name in dir(betterproto.Message):
+            return f"{unsafe_name}_"
+        return unsafe_name
 
     @property
     def proto_name(self) -> str:

--- a/tests/inputs/rename/rename.proto
+++ b/tests/inputs/rename/rename.proto
@@ -1,0 +1,7 @@
+// The fields that have overlapping names with betterproto.Message will be renamed.
+message Renamed {
+    optional bool parse = 1;
+    optional bool serialized_on_wire = 2;
+    optional bool from_json = 3;
+    optional int32 this = 4;
+}

--- a/tests/inputs/rename/test_rename.py
+++ b/tests/inputs/rename/test_rename.py
@@ -1,0 +1,12 @@
+from dataclasses import fields
+
+from tests.output_betterproto.rename import Renamed
+
+
+def test_renamed_fields():
+    assert {field.name for field in fields(Renamed)} == {
+        "parse_",
+        "serialized_on_wire_",
+        "from_json_",
+        "this",
+    }


### PR DESCRIPTION
Follows from a conversation with @danielgtaylor 

parse -> parse_
serialized_on_wire -> serialized_on_wire_
foo -> foo

This allows us to reserve names for betterproto. I'll need to document this somewhere.