### PR TITLE
test input: use explicit package declaration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [Ubuntu, MacOS, Windows]
         python-version: ['3.6.7', '3.7', '3.8', '3.9', '3.10']
@@ -56,9 +57,7 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: |
-          poetry run python -m pip install pip -U
-          poetry install
+        run: poetry install
 
       - name: Generate code from proto files
         shell: bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import copy
+import sys
+
 import pytest
 
 
@@ -10,3 +13,10 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="session")
 def repeat(request):
     return request.config.getoption("repeat")
+
+
+@pytest.fixture
+def reset_sys_path():
+    original = copy.deepcopy(sys.path)
+    yield
+    sys.path = original

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -78,7 +78,7 @@ async def generate_test_case_output(
     """
 
     test_case_output_path_reference = output_path_reference.joinpath(test_case_name)
-    test_case_output_path_betterproto = output_path_betterproto.joinpath(test_case_name)
+    test_case_output_path_betterproto = output_path_betterproto
 
     os.makedirs(test_case_output_path_reference, exist_ok=True)
     os.makedirs(test_case_output_path_betterproto, exist_ok=True)

--- a/tests/grpc/test_grpclib_client.py
+++ b/tests/grpc/test_grpclib_client.py
@@ -7,12 +7,12 @@ import grpclib.server
 import pytest
 from betterproto.grpc.util.async_channel import AsyncChannel
 from grpclib.testing import ChannelFor
-from tests.output_betterproto.service.service import (
+from tests.output_betterproto.service import (
     DoThingRequest,
     DoThingResponse,
     GetThingRequest,
 )
-from tests.output_betterproto.service.service import TestStub as ThingServiceClient
+from tests.output_betterproto.service import TestStub as ThingServiceClient
 
 from .thing_service import ThingService
 

--- a/tests/grpc/thing_service.py
+++ b/tests/grpc/thing_service.py
@@ -1,4 +1,4 @@
-from tests.output_betterproto.service.service import (
+from tests.output_betterproto.service import (
     DoThingResponse,
     DoThingRequest,
     GetThingRequest,

--- a/tests/inputs/bool/bool.proto
+++ b/tests/inputs/bool/bool.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package bool;
+
 message Test {
     bool value = 1;
 }

--- a/tests/inputs/bytes/bytes.proto
+++ b/tests/inputs/bytes/bytes.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package bytes;
+
 message Test {
     bytes data = 1;
 }

--- a/tests/inputs/casing/casing.proto
+++ b/tests/inputs/casing/casing.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package casing;
+
 enum my_enum {
   ZERO = 0;
   ONE = 1;

--- a/tests/inputs/casing_message_field_uppercase/casing_message_field_uppercase.proto
+++ b/tests/inputs/casing_message_field_uppercase/casing_message_field_uppercase.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package casing_message_field_uppercase;
+
 message Test {
   int32 UPPERCASE = 1;
   int32 UPPERCASE_V2 = 2;

--- a/tests/inputs/deprecated/deprecated.proto
+++ b/tests/inputs/deprecated/deprecated.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package deprecated;
+
 // Some documentation about the Test message.
 message Test {
     // Some documentation about the value.

--- a/tests/inputs/deprecated_field/deprecated_field.proto
+++ b/tests/inputs/deprecated_field/deprecated_field.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package deprecated_field;
+
 // Some documentation about the Test message.
 message Test {
     // Some documentation about the value.

--- a/tests/inputs/double/double.proto
+++ b/tests/inputs/double/double.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package double;
+
 message Test {
     double count = 1;
 }

--- a/tests/inputs/empty_repeated/empty_repeated.proto
+++ b/tests/inputs/empty_repeated/empty_repeated.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package empty_repeated;
+
 message MessageA {
   repeated float values = 1;
 }

--- a/tests/inputs/enum/enum.proto
+++ b/tests/inputs/enum/enum.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package enum;
+
 // Tests that enums are correctly serialized and that it correctly handles skipped and out-of-order enum values
 message Test {
   Choice choice = 1;

--- a/tests/inputs/example/example.proto
+++ b/tests/inputs/example/example.proto
@@ -39,6 +39,8 @@
 
 syntax = "proto2";
 
+package example;
+
 // package google.protobuf;
 
 option go_package = "google.golang.org/protobuf/types/descriptorpb";

--- a/tests/inputs/example_service/test_example_service.py
+++ b/tests/inputs/example_service/test_example_service.py
@@ -2,7 +2,7 @@ from typing import AsyncIterable, AsyncIterator
 
 import pytest
 from grpclib.testing import ChannelFor
-from tests.output_betterproto.example_service.example_service import (
+from tests.output_betterproto.example_service import (
     ExampleRequest,
     ExampleResponse,
     TestBase,

--- a/tests/inputs/field_name_identical_to_type/field_name_identical_to_type.proto
+++ b/tests/inputs/field_name_identical_to_type/field_name_identical_to_type.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package field_name_identical_to_type;
+
 // Tests that messages may contain fields with names that are identical to their python types (PR #294)
 
 message Test {

--- a/tests/inputs/fixed/fixed.proto
+++ b/tests/inputs/fixed/fixed.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package fixed;
+
 message Test {
   fixed32 foo = 1;
   sfixed32 bar = 2;

--- a/tests/inputs/float/float.proto
+++ b/tests/inputs/float/float.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package float;
+
 // Some documentation about the Test message.
 message Test {
     double positive = 1;

--- a/tests/inputs/google_impl_behavior_equivalence/google_impl_behavior_equivalence.proto
+++ b/tests/inputs/google_impl_behavior_equivalence/google_impl_behavior_equivalence.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package google_impl_behavior_equivalence;
+
 message Foo{
   int64 bar = 1;
 }

--- a/tests/inputs/googletypes/googletypes.proto
+++ b/tests/inputs/googletypes/googletypes.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package googletypes;
+
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";

--- a/tests/inputs/googletypes_response/googletypes_response.proto
+++ b/tests/inputs/googletypes_response/googletypes_response.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package googletypes_response;
+
 import "google/protobuf/wrappers.proto";
 
 // Tests that wrapped values can be used directly as return values

--- a/tests/inputs/googletypes_response_embedded/googletypes_response_embedded.proto
+++ b/tests/inputs/googletypes_response_embedded/googletypes_response_embedded.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package googletypes_response_embedded;
+
 import "google/protobuf/wrappers.proto";
 
 // Tests that wrapped values are supported as part of output message

--- a/tests/inputs/googletypes_service_returns_empty/googletypes_service_returns_empty.proto
+++ b/tests/inputs/googletypes_service_returns_empty/googletypes_service_returns_empty.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package googletypes_service_returns_empty;
+
 import "google/protobuf/empty.proto";
 
 service Test {

--- a/tests/inputs/googletypes_service_returns_googletype/googletypes_service_returns_googletype.proto
+++ b/tests/inputs/googletypes_service_returns_googletype/googletypes_service_returns_googletype.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package googletypes_service_returns_googletype;
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 

--- a/tests/inputs/googletypes_struct/googletypes_struct.proto
+++ b/tests/inputs/googletypes_struct/googletypes_struct.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package googletypes_struct;
+
 import "google/protobuf/struct.proto";
 
 message Test {

--- a/tests/inputs/googletypes_value/googletypes_value.proto
+++ b/tests/inputs/googletypes_value/googletypes_value.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package googletypes_value;
+
 import "google/protobuf/struct.proto";
 
 // Tests that fields of type google.protobuf.Value can contain arbitrary JSON-values.

--- a/tests/inputs/import_capitalized_package/capitalized.proto
+++ b/tests/inputs/import_capitalized_package/capitalized.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 
-package Capitalized;
+package import_capitalized_package.Capitalized;
 
 message Message {
 

--- a/tests/inputs/import_capitalized_package/test.proto
+++ b/tests/inputs/import_capitalized_package/test.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package import_capitalized_package;
+
 import "capitalized.proto";
 
 // Tests that we can import from a package with a capital name, that looks like a nested type, but isn't.

--- a/tests/inputs/import_child_package_from_package/child.proto
+++ b/tests/inputs/import_child_package_from_package/child.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package package.childpackage;
+package import_child_package_from_package.package.childpackage;
 
 message ChildMessage {
 

--- a/tests/inputs/import_child_package_from_package/import_child_package_from_package.proto
+++ b/tests/inputs/import_child_package_from_package/import_child_package_from_package.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package import_child_package_from_package;
+
 import "package_message.proto";
 
 // Tests generated imports when a message in a package refers to a message in a nested child package.

--- a/tests/inputs/import_child_package_from_package/package_message.proto
+++ b/tests/inputs/import_child_package_from_package/package_message.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "child.proto";
 
-package package;
+package import_child_package_from_package.package;
 
 message PackageMessage {
     package.childpackage.ChildMessage c = 1;

--- a/tests/inputs/import_child_package_from_root/child.proto
+++ b/tests/inputs/import_child_package_from_root/child.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package childpackage;
+package import_child_package_from_root.childpackage;
 
 message Message {
 

--- a/tests/inputs/import_child_package_from_root/import_child_package_from_root.proto
+++ b/tests/inputs/import_child_package_from_root/import_child_package_from_root.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package import_child_package_from_root;
+
 import "child.proto";
 
 // Tests generated imports when a message in root refers to a message in a child package.

--- a/tests/inputs/import_circular_dependency/import_circular_dependency.proto
+++ b/tests/inputs/import_circular_dependency/import_circular_dependency.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package import_circular_dependency;
+
 import "root.proto";
 import "other.proto";
 

--- a/tests/inputs/import_circular_dependency/other.proto
+++ b/tests/inputs/import_circular_dependency/other.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 import "root.proto";
-package other;
+package import_circular_dependency.other;
 
 message OtherPackageMessage {
     RootPackageMessage rootPackageMessage = 1;

--- a/tests/inputs/import_circular_dependency/root.proto
+++ b/tests/inputs/import_circular_dependency/root.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package import_circular_dependency;
+
 message RootPackageMessage {
 
 }

--- a/tests/inputs/import_cousin_package/cousin.proto
+++ b/tests/inputs/import_cousin_package/cousin.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package cousin.cousin_subpackage;
+package import_cousin_package.cousin.cousin_subpackage;
 
 message CousinMessage {
 }

--- a/tests/inputs/import_cousin_package/test.proto
+++ b/tests/inputs/import_cousin_package/test.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package test.subpackage;
+package import_cousin_package.test.subpackage;
 
 import "cousin.proto";
 

--- a/tests/inputs/import_cousin_package_same_name/cousin.proto
+++ b/tests/inputs/import_cousin_package_same_name/cousin.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package cousin.subpackage;
+package import_cousin_package_same_name.cousin.subpackage;
 
 message CousinMessage {
 }

--- a/tests/inputs/import_cousin_package_same_name/test.proto
+++ b/tests/inputs/import_cousin_package_same_name/test.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package test.subpackage;
+package import_cousin_package_same_name.test.subpackage;
 
 import "cousin.proto";
 

--- a/tests/inputs/import_packages_same_name/import_packages_same_name.proto
+++ b/tests/inputs/import_packages_same_name/import_packages_same_name.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package import_packages_same_name;
+
 import "users_v1.proto";
 import "posts_v1.proto";
 

--- a/tests/inputs/import_packages_same_name/posts_v1.proto
+++ b/tests/inputs/import_packages_same_name/posts_v1.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package posts.v1;
+package import_packages_same_name.posts.v1;
 
 message Post {
 

--- a/tests/inputs/import_packages_same_name/users_v1.proto
+++ b/tests/inputs/import_packages_same_name/users_v1.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package users.v1;
+package import_packages_same_name.users.v1;
 
 message User {
 

--- a/tests/inputs/import_parent_package_from_child/import_parent_package_from_child.proto
+++ b/tests/inputs/import_parent_package_from_child/import_parent_package_from_child.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "parent_package_message.proto";
 
-package parent.child;
+package import_parent_package_from_child.parent.child;
 
 // Tests generated imports when a message refers to a message defined in its parent package
 

--- a/tests/inputs/import_parent_package_from_child/parent_package_message.proto
+++ b/tests/inputs/import_parent_package_from_child/parent_package_message.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package parent;
+package import_parent_package_from_child.parent;
 
 message ParentPackageMessage {
 }

--- a/tests/inputs/import_root_package_from_child/child.proto
+++ b/tests/inputs/import_root_package_from_child/child.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package child;
+package import_root_package_from_child.child;
 
 import "root.proto";
 

--- a/tests/inputs/import_root_package_from_child/root.proto
+++ b/tests/inputs/import_root_package_from_child/root.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package import_root_package_from_child;
+
 
 message RootMessage {
 }

--- a/tests/inputs/import_root_sibling/import_root_sibling.proto
+++ b/tests/inputs/import_root_sibling/import_root_sibling.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package import_root_sibling;
+
 import "sibling.proto";
 
 // Tests generated imports when a message in the root package refers to another message in the root package

--- a/tests/inputs/import_root_sibling/sibling.proto
+++ b/tests/inputs/import_root_sibling/sibling.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package import_root_sibling;
+
 message SiblingMessage {
 
 }

--- a/tests/inputs/import_service_input_message/child_package_request_message.proto
+++ b/tests/inputs/import_service_input_message/child_package_request_message.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package child;
+package import_service_input_message.child;
 
 message ChildRequestMessage {
     int32 child_argument = 1;

--- a/tests/inputs/import_service_input_message/import_service_input_message.proto
+++ b/tests/inputs/import_service_input_message/import_service_input_message.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package import_service_input_message;
+
 import "request_message.proto";
 import "child_package_request_message.proto";
 

--- a/tests/inputs/import_service_input_message/request_message.proto
+++ b/tests/inputs/import_service_input_message/request_message.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package import_service_input_message;
+
 message RequestMessage {
     int32 argument = 1;
 }

--- a/tests/inputs/int32/int32.proto
+++ b/tests/inputs/int32/int32.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package int32;
+
 // Some documentation about the Test message.
 message Test {
     // Some documentation about the count.

--- a/tests/inputs/map/map.proto
+++ b/tests/inputs/map/map.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package map;
+
 message Test {
     map<string, int32> counts = 1;
 }

--- a/tests/inputs/mapmessage/mapmessage.proto
+++ b/tests/inputs/mapmessage/mapmessage.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package mapmessage;
+
 message Test {
   map<string, Nested> items = 1;
 }

--- a/tests/inputs/namespace_builtin_types/namespace_builtin_types.proto
+++ b/tests/inputs/namespace_builtin_types/namespace_builtin_types.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package namespace_builtin_types;
+
 // Tests that messages may contain fields with names that are python types
 
 message Test {

--- a/tests/inputs/namespace_keywords/namespace_keywords.proto
+++ b/tests/inputs/namespace_keywords/namespace_keywords.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package namespace_keywords;
+
 // Tests that messages may contain fields that are Python keywords
 //
 // Generated with Python 3.7.6

--- a/tests/inputs/nested/nested.proto
+++ b/tests/inputs/nested/nested.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package nested;
+
 // A test message with a nested message inside of it.
 message Test {
     // This is the nested type.

--- a/tests/inputs/nested2/nested2.proto
+++ b/tests/inputs/nested2/nested2.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package nested2;
+
 import "package.proto";
 
 message Game {

--- a/tests/inputs/nested2/package.proto
+++ b/tests/inputs/nested2/package.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package equipment;
+package nested2.equipment;
 
 message Weapon {
 

--- a/tests/inputs/nestedtwice/nestedtwice.proto
+++ b/tests/inputs/nestedtwice/nestedtwice.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package nestedtwice;
+
 message Test {
   message Top {
     message Middle {

--- a/tests/inputs/oneof/oneof.proto
+++ b/tests/inputs/oneof/oneof.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package oneof;
+
 message Test {
   oneof foo {
     int32 pitied = 1;

--- a/tests/inputs/oneof_default_value_serialization/oneof_default_value_serialization.proto
+++ b/tests/inputs/oneof_default_value_serialization/oneof_default_value_serialization.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package oneof_default_value_serialization;
+
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";

--- a/tests/inputs/oneof_empty/oneof_empty.proto
+++ b/tests/inputs/oneof_empty/oneof_empty.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package oneof_empty;
+
 message Nothing {}
 
 message MaybeNothing {

--- a/tests/inputs/oneof_enum/oneof_enum.proto
+++ b/tests/inputs/oneof_enum/oneof_enum.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package oneof_enum;
+
 message Test {
   oneof action {
     Signal signal = 1;

--- a/tests/inputs/proto3_field_presence/proto3_field_presence.proto
+++ b/tests/inputs/proto3_field_presence/proto3_field_presence.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package proto3_field_presence;
+
 import "google/protobuf/timestamp.proto";
 
 message InnerTest {

--- a/tests/inputs/proto3_field_presence_oneof/proto3_field_presence_oneof.proto
+++ b/tests/inputs/proto3_field_presence_oneof/proto3_field_presence_oneof.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package proto3_field_presence_oneof;
+
 message Test {
     oneof kind {
         Nested nested = 1;

--- a/tests/inputs/recursivemessage/recursivemessage.proto
+++ b/tests/inputs/recursivemessage/recursivemessage.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package recursivemessage;
+
 message Test {
     string name = 1;
     Test child = 2;

--- a/tests/inputs/ref/ref.proto
+++ b/tests/inputs/ref/ref.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package ref;
+
 import "repeatedmessage.proto";
 
 message Test {

--- a/tests/inputs/repeated/repeated.proto
+++ b/tests/inputs/repeated/repeated.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package repeated;
+
 message Test {
     repeated string names = 1;
 }

--- a/tests/inputs/repeated_duration_timestamp/repeated_duration_timestamp.proto
+++ b/tests/inputs/repeated_duration_timestamp/repeated_duration_timestamp.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package repeated_duration_timestamp;
+
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 

--- a/tests/inputs/repeatedpacked/repeatedpacked.proto
+++ b/tests/inputs/repeatedpacked/repeatedpacked.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package repeatedpacked;
+
 message Test {
     repeated int32 counts = 1;
     repeated sint64 signed = 2;

--- a/tests/inputs/service_separate_packages/messages.proto
+++ b/tests/inputs/service_separate_packages/messages.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-package things.messages;
+package service_separate_packages.things.messages;
 
 message DoThingRequest {
   string name = 1;

--- a/tests/inputs/service_separate_packages/service.proto
+++ b/tests/inputs/service_separate_packages/service.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "messages.proto";
 
-package things.service;
+package service_separate_packages.things.service;
 
 service Test {
   rpc DoThing (things.messages.DoThingRequest) returns (things.messages.DoThingResponse);

--- a/tests/inputs/signed/signed.proto
+++ b/tests/inputs/signed/signed.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package signed;
+
 message Test {
     // todo: rename fields after fixing bug where 'signed_32_positive' will map to 'signed_32Positive' as output json
     sint32 signed32 = 1;    //  signed_32_positive

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -480,7 +480,7 @@ def test_iso_datetime_list():
 
 
 def test_service_argument__expected_parameter():
-    from tests.output_betterproto.service.service import TestStub
+    from tests.output_betterproto.service import TestStub
 
     sig = signature(TestStub.do_thing)
     do_thing_request_parameter = sig.parameters["do_thing_request"]

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -23,8 +23,6 @@ from tests.util import (
 # break things because we can't properly reset the symbol database.
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
-from google.protobuf import symbol_database
-from google.protobuf.descriptor_pool import DescriptorPool
 from google.protobuf.json_format import Parse
 
 
@@ -125,13 +123,8 @@ def dict_replace_nans(input_dict: Dict[Any, Any]) -> Dict[Any, Any]:
 
 
 @pytest.fixture
-def test_data(request):
+def test_data(request, reset_sys_path):
     test_case_name = request.param
-
-    # Reset the internal symbol database so we can import the `Test` message
-    # multiple times. Ugh.
-    sym = symbol_database.Default()
-    sym.pool = DescriptorPool()
 
     reference_module_root = os.path.join(
         *reference_output_package.split("."), test_case_name
@@ -157,8 +150,6 @@ def test_data(request):
             json_data=get_test_case_json_data(test_case_name),
         )
     )
-
-    sys.path.remove(reference_module_root)
 
 
 @pytest.mark.parametrize("test_data", test_cases.messages, indirect=True)


### PR DESCRIPTION
This change ensures that tests run successfully against new versions
of python-protobuf. Without this change, due to the nature of testing
there will arise conflict exceptions.

This change also removes manual reset of symbol database in binary
compatibility tests as well as ensure `sys.path` reset happens
reliably.