### PR TITLE
tests.generate: remove deprecated get_event_loop

### DIFF
--- a/tests/generate.py
+++ b/tests/generate.py
@@ -161,7 +161,11 @@ def main():
     if platform.system() == "Windows":
         asyncio.set_event_loop(asyncio.ProactorEventLoop())
 
-    asyncio.get_event_loop().run_until_complete(generate(whitelist, verbose))
+    try:
+        asyncio.run(generate(whitelist, verbose))
+    except AttributeError:
+        # compatibility code for python < 3.7
+        asyncio.get_event_loop().run_until_complete(generate(whitelist, verbose))
 
 
 if __name__ == "__main__":

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -159,7 +159,13 @@ def main():
         whitelist = set(sys.argv[1:])
 
     if platform.system() == "Windows":
-        asyncio.set_event_loop(asyncio.ProactorEventLoop())
+        # for python version prior to 3.8, loop policy needs to be set explicitly
+        # https://docs.python.org/3/library/asyncio-policy.html#asyncio.DefaultEventLoopPolicy
+        try:
+            asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+        except AttributeError:
+            # python < 3.7 does not have asyncio.WindowsProactorEventLoopPolicy
+            asyncio.get_event_loop_policy().set_event_loop(asyncio.ProactorEventLoop())
 
     try:
         asyncio.run(generate(whitelist, verbose))


### PR DESCRIPTION
The use of `asyncio.get_event_loop()` has been deprecated in python
3.10+. We replace this usage with `asyncio.run()` for python 3.7+.

**References:**
- https://bugs.python.org/issue38599
- https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop
