### PR TITLE
Fix: get documentation for nested enums

### DIFF
--- a/tests/inputs/nestedtwice/nestedtwice.proto
+++ b/tests/inputs/nestedtwice/nestedtwice.proto
@@ -2,27 +2,39 @@ syntax = "proto3";
 
 package nestedtwice;
 
+/* Test doc. */
 message Test {
+  /* Top doc. */
   message Top {
+    /* Middle doc. */
     message Middle {
+      /* TopMiddleBottom doc.*/
       message TopMiddleBottom {
+        // TopMiddleBottom.a doc.
         string a = 1;
       }
+      /* EnumBottom doc. */
       enum EnumBottom{
+        /* EnumBottom.A doc. */
         A = 0;
         B = 1;
       }
+      /* Bottom doc. */
       message Bottom {
+        /* Bottom.foo doc. */
         string foo = 1;
       }
       reserved 1;
+      /* Middle.bottom doc. */
       repeated Bottom bottom = 2;
       repeated EnumBottom enumBottom=3;
       repeated TopMiddleBottom topMiddleBottom=4;
       bool bar = 5;
     }
+    /* Top.name doc. */
     string name = 1;
     Middle middle = 2;
   }
+  /* Test.top doc. */
   Top top = 1;
 }

--- a/tests/inputs/nestedtwice/test_nestedtwice.py
+++ b/tests/inputs/nestedtwice/test_nestedtwice.py
@@ -1,0 +1,25 @@
+import pytest
+
+from tests.output_betterproto.nestedtwice import (
+    Test,
+    TestTop,
+    TestTopMiddle,
+    TestTopMiddleBottom,
+    TestTopMiddleEnumBottom,
+    TestTopMiddleTopMiddleBottom,
+)
+
+
+@pytest.mark.parametrize(
+    ("cls", "expected_comment"),
+    [
+        (Test, "Test doc."),
+        (TestTopMiddleEnumBottom, "EnumBottom doc."),
+        (TestTop, "Top doc."),
+        (TestTopMiddle, "Middle doc."),
+        (TestTopMiddleTopMiddleBottom, "TopMiddleBottom doc."),
+        (TestTopMiddleBottom, "Bottom doc."),
+    ],
+)
+def test_comment(cls, expected_comment):
+    assert cls.__doc__ == expected_comment


### PR DESCRIPTION
When iterating on nested enums the index of the enum was not added in the path so no documentation could be extracted.
Also using `yield from` for more clarity and fixed the type annotations.