### PR TITLE
Fix is_set for optional proto3 fields

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1317,7 +1317,8 @@ class Message(ABC):
         :class:`bool`
             `True` if field has been set, otherwise `False`.
         """
-        return self.__raw_get(name) is not PLACEHOLDER
+        default = PLACEHOLDER if self._betterproto.meta_by_field_name[name].optional is None else None
+        return self.__raw_get(name) is not default
 
 
 def serialized_on_wire(message: Message) -> bool:

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1317,7 +1317,11 @@ class Message(ABC):
         :class:`bool`
             `True` if field has been set, otherwise `False`.
         """
-        default = PLACEHOLDER if self._betterproto.meta_by_field_name[name].optional is None else None
+        default = (
+            PLACEHOLDER
+            if self._betterproto.meta_by_field_name[name].optional is None
+            else None
+        )
         return self.__raw_get(name) is not default
 
 

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1319,7 +1319,7 @@ class Message(ABC):
         """
         default = (
             PLACEHOLDER
-            if self._betterproto.meta_by_field_name[name].optional is None
+            if not self._betterproto.meta_by_field_name[name].optional
             else None
         )
         return self.__raw_get(name) is not default

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -517,3 +517,13 @@ def test_copyability():
     assert spam == deepcopied
     assert spam is not deepcopied
     assert spam.baz is not deepcopied.baz
+
+
+def test_is_set():
+    @dataclass
+    class Spam(betterproto.Message):
+        foo: bool = betterproto.bool_field(1)
+        bar: Optional[int] = betterproto.int32_field(2, optional=True)
+
+    assert not Spam().is_set("foo")
+    assert not Spam().is_set("bar")

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -528,3 +528,4 @@ def test_is_set():
     assert not Spam().is_set("foo")
     assert not Spam().is_set("bar")
     assert Spam(foo=True).is_set("foo")
+    assert Spam(foo=True, bar=0).is_set("bar")

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -527,3 +527,4 @@ def test_is_set():
 
     assert not Spam().is_set("foo")
     assert not Spam().is_set("bar")
+    assert Spam(foo=True).is_set("foo")


### PR DESCRIPTION
It just occured to me that this was broken, realistically however this is easy enough for the end user to perform. 