### PR TITLE
Pull down the `include_default_values` argument to `to_json`

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1260,7 +1260,9 @@ class Message(ABC):
                     setattr(self, field_name, v)
         return self
 
-    def to_json(self, indent: Union[None, int, str] = None) -> str:
+    def to_json(
+        self, indent: Union[None, int, str] = None, include_default_values: bool = False
+    ) -> str:
         """A helper function to parse the message instance into its JSON
         representation.
 
@@ -1273,12 +1275,19 @@ class Message(ABC):
         indent: Optional[Union[:class:`int`, :class:`str`]]
             The indent to pass to :func:`json.dumps`.
 
+        include_default_values: :class:`bool`
+            If ``True`` will include the default values of fields. Default is ``False``.
+            E.g. an ``int32`` field will be included with a value of ``0`` if this is
+            set to ``True``, otherwise this would be ignored.
+
         Returns
         --------
         :class:`str`
             The JSON representation of the message.
         """
-        return json.dumps(self.to_dict(), indent=indent)
+        return json.dumps(
+            self.to_dict(include_default_values=include_default_values), indent=indent
+        )
 
     def from_json(self: T, value: Union[str, bytes]) -> T:
         """A helper function to return the message instance from its JSON

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1261,7 +1261,10 @@ class Message(ABC):
         return self
 
     def to_json(
-        self, indent: Union[None, int, str] = None, include_default_values: bool = False
+        self,
+        indent: Union[None, int, str] = None,
+        include_default_values: bool = False,
+        casing: Casing = Casing.CAMEL,
     ) -> str:
         """A helper function to parse the message instance into its JSON
         representation.
@@ -1280,13 +1283,18 @@ class Message(ABC):
             E.g. an ``int32`` field will be included with a value of ``0`` if this is
             set to ``True``, otherwise this would be ignored.
 
+        casing: :class:`Casing`
+            The casing to use for key values. Default is :attr:`Casing.CAMEL` for
+            compatibility purposes.
+
         Returns
         --------
         :class:`str`
             The JSON representation of the message.
         """
         return json.dumps(
-            self.to_dict(include_default_values=include_default_values), indent=indent
+            self.to_dict(include_default_values=include_default_values, casing=casing),
+            indent=indent,
         )
 
     def from_json(self: T, value: Union[str, bytes]) -> T:


### PR DESCRIPTION
The `to_json` method does not include the `include_default_values`
option from `to_dict`. While the implementation to `to_json` is
almost litteraly only a call to `to_dict()` (and thus trivial to
replace), it is more convenient for users to not have to reimplement it
when the option is desired.