### PR TITLE
Enforce `serialize_empty` for repeated fields

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -806,6 +806,7 @@ class Message(ABC):
                                 meta.proto_type,
                                 item,
                                 wraps=meta.wraps or "",
+                                serialize_empty=True,
                             )
                             # if it's an empty message it still needs to be represented
                             # as an item in the repeated list

--- a/tests/inputs/regression_387/regression_387.proto
+++ b/tests/inputs/regression_387/regression_387.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package regression_387;
+
+message Test {
+  uint64 id = 1;
+}
+
+message ParentElement {
+  string name = 1;
+  repeated Test elems = 2;
+}

--- a/tests/inputs/regression_387/test_regression_387.py
+++ b/tests/inputs/regression_387/test_regression_387.py
@@ -1,4 +1,7 @@
-from tests.output_betterproto.regression_387 import Test, ParentElement
+from tests.output_betterproto.regression_387 import (
+    Test,
+    ParentElement,
+)
 
 
 def test_regression_387():

--- a/tests/inputs/regression_387/test_regression_387.py
+++ b/tests/inputs/regression_387/test_regression_387.py
@@ -1,6 +1,6 @@
 from tests.output_betterproto.regression_387 import (
-    Test,
     ParentElement,
+    Test,
 )
 
 

--- a/tests/inputs/regression_387/test_regression_387.py
+++ b/tests/inputs/regression_387/test_regression_387.py
@@ -1,0 +1,9 @@
+from tests.output_betterproto.regression_387 import Test, ParentElement
+
+
+def test_regression_387():
+    el = ParentElement(name="test", elems=[Test(id=0), Test(id=42)])
+    binary = bytes(el)
+    decoded = ParentElement().parse(binary)
+    assert decoded == el
+    assert decoded.elems == [Test(id=0), Test(id=42)]

--- a/tests/inputs/regression_414/regression_414.proto
+++ b/tests/inputs/regression_414/regression_414.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package regression_414;
+
+message Test {
+  bytes body = 1;
+  bytes auth = 2;
+  repeated bytes signatures = 3;
+}

--- a/tests/inputs/regression_414/test_regression_414.py
+++ b/tests/inputs/regression_414/test_regression_414.py
@@ -1,0 +1,15 @@
+from tests.output_betterproto.regression_414 import Test
+
+
+def test_full_cycle():
+    body = bytes([0, 1])
+    auth = bytes([2, 3])
+    sig = [b""]
+
+    obj = Test(body=body, auth=auth, signatures=sig)
+
+    decoded = Test().parse(bytes(obj))
+    assert decoded == obj
+    assert decoded.body == body
+    assert decoded.auth == auth
+    assert decoded.signatures == sig


### PR DESCRIPTION
When serializing a sequence of elements, `serialize_empty` must be `True` to prevent data loss and messages incompatible with original `protobuf` implementation. 

Closes #414
Closes #387 
