### PR TITLE
Pythonize input_type name in py_input_message

### DIFF
--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -750,7 +750,7 @@ class ServiceMethodCompiler(ProtoContentBase):
         # comparable with method.input_type
         for msg in self.request.all_messages:
             if (
-                msg.py_name == name.replace(".", "")
+                msg.py_name == pythonize_class_name(name.replace(".", ""))
                 and msg.output_file.package == package
             ):
                 return msg

--- a/tests/inputs/config.py
+++ b/tests/inputs/config.py
@@ -19,6 +19,7 @@ services = {
     "googletypes_service_returns_googletype",
     "example_service",
     "empty_service",
+    "service_uppercase",
 }
 
 

--- a/tests/inputs/service_uppercase/service.proto
+++ b/tests/inputs/service_uppercase/service.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package service_uppercase;
+
+message DoTHINGRequest {
+  string name = 1;
+  repeated string comments = 2;
+}
+
+message DoTHINGResponse {
+  repeated string names = 1;
+}
+
+service Test {
+  rpc DoThing (DoTHINGRequest) returns (DoTHINGResponse);
+}

--- a/tests/inputs/service_uppercase/test_service.py
+++ b/tests/inputs/service_uppercase/test_service.py
@@ -1,0 +1,7 @@
+import inspect
+from tests.output_betterproto.service_uppercase import TestStub
+
+
+def test_parameters():
+    sig = inspect.signature(TestStub.do_thing)
+    assert len(sig.parameters) == 5, "Expected 5 parameters"

--- a/tests/inputs/service_uppercase/test_service.py
+++ b/tests/inputs/service_uppercase/test_service.py
@@ -1,4 +1,5 @@
 import inspect
+
 from tests.output_betterproto.service_uppercase import TestStub
 
 


### PR DESCRIPTION
Fixes https://github.com/danielgtaylor/python-betterproto/issues/427
Fixes #438 