### PR TITLE
Enforce decimal notation for timedelta JSON representation

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1532,8 +1532,9 @@ class _Duration(Duration):
 
     @staticmethod
     def delta_to_json(delta: timedelta) -> str:
-        parts = str(delta.total_seconds()).split(".")
+        parts = f"{delta.total_seconds():f}".split(".")
         if len(parts) > 1:
+            parts[1] = parts[1].rstrip('0')
             while len(parts[1]) not in (3, 6, 9):
                 parts[1] = f"{parts[1]}0"
         return f"{'.'.join(parts)}s"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -439,20 +439,30 @@ def test_to_dict_datetime_values():
     class TestDatetimeMessage(betterproto.Message):
         bar: datetime = betterproto.message_field(1)
         baz: timedelta = betterproto.message_field(2)
+        bat: timedelta = betterproto.message_field(3)
 
     test = TestDatetimeMessage().from_dict(
-        {"bar": "2020-01-01T00:00:00Z", "baz": "86400.000s"}
+        {"bar": "2020-01-01T00:00:00Z", "baz": "86400.000s", "bat": "0.000001s"}
     )
 
-    assert test.to_dict() == {"bar": "2020-01-01T00:00:00Z", "baz": "86400.000s"}
+    assert test.to_dict() == {
+        "bar": "2020-01-01T00:00:00Z",
+        "baz": "86400.000s",
+        "bat":"0.000001s",
+    }
 
     test = TestDatetimeMessage().from_pydict(
-        {"bar": datetime(year=2020, month=1, day=1), "baz": timedelta(days=1)}
+        {
+            "bar": datetime(year=2020, month=1, day=1),
+            "baz": timedelta(days=1),
+            "bat": timedelta(microseconds=1),
+        }
     )
 
     assert test.to_pydict() == {
         "bar": datetime(year=2020, month=1, day=1),
         "baz": timedelta(days=1),
+        "bat": timedelta(microseconds=1),
     }
 
 


### PR DESCRIPTION
Fixes #447