### PR TITLE
Fix for #459 (pydantic code gen only)

### DIFF
--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -7,7 +7,11 @@ import {{ i }}
 {% endfor %}
 
 {% if output_file.pydantic_dataclasses %}
-from pydantic.dataclasses import dataclass
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from dataclasses import dataclass
+else:
+    from pydantic.dataclasses import dataclass
 {%- else -%}
 from dataclasses import dataclass
 {% endif %}


### PR DESCRIPTION
This pull request addresses my concerns with how the oneofs groups are generated for `optional` fields in proto3 files. This stops pydantic from complaining that the groups have unset values when the field is optional.

I also re-included the old

```python
from typing import TYPE_CHECKING
if TYPE_CHECKING:
    from dataclasses import dataclass
else:
    from pydantic.dataclasses import dataclass
```

In pull request #406 it was decided to remove it, but it causes issues with keywords arguments and `mypy` v >= 1.0.0