### PR TITLE
Handle empty value objects properly

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -704,6 +704,10 @@ class Message(ABC):
             return value
 
     def __setattr__(self, attr: str, value: Any) -> None:
+    
+        if hasattr(value, "_serialized_on_wire") and hasattr(value, "_betterproto") and len(value._betterproto.meta_by_field_name) == 0:
+            value._serialized_on_wire = True
+    
         if attr != "_serialized_on_wire":
             # Track when a field has been set.
             self.__dict__["_serialized_on_wire"] = True

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -704,7 +704,11 @@ class Message(ABC):
             return value
 
     def __setattr__(self, attr: str, value: Any) -> None:
-        if isinstance(value, Message) and hasattr(value, "_betterproto") and not len(value._betterproto.meta_by_field_name):
+        if (
+            isinstance(value, Message) 
+            and hasattr(value, "_betterproto") 
+            and not len(value._betterproto.meta_by_field_name)
+        ):
             value._serialized_on_wire = True
     
         if attr != "_serialized_on_wire":

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -707,7 +707,7 @@ class Message(ABC):
         if (
             isinstance(value, Message)
             and hasattr(value, "_betterproto")
-            and not len(value._betterproto.meta_by_field_name)
+            and not value._betterproto.meta_by_field_name
         ):
             value._serialized_on_wire = True
 
@@ -1483,6 +1483,7 @@ class Message(ABC):
         field_name_to_meta = cls._betterproto_meta.meta_by_field_name  # type: ignore
 
         for group, field_set in group_to_one_ofs.items():
+
             if len(field_set) == 1:
                 (field,) = field_set
                 field_name = field.name

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -704,8 +704,7 @@ class Message(ABC):
             return value
 
     def __setattr__(self, attr: str, value: Any) -> None:
-    
-        if hasattr(value, "_serialized_on_wire") and hasattr(value, "_betterproto") and len(value._betterproto.meta_by_field_name) == 0:
+        if isinstance(value, Message) and hasattr(value, "_betterproto") and not len(value._betterproto.meta_by_field_name):
             value._serialized_on_wire = True
     
         if attr != "_serialized_on_wire":

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -705,12 +705,12 @@ class Message(ABC):
 
     def __setattr__(self, attr: str, value: Any) -> None:
         if (
-            isinstance(value, Message) 
-            and hasattr(value, "_betterproto") 
+            isinstance(value, Message)
+            and hasattr(value, "_betterproto")
             and not len(value._betterproto.meta_by_field_name)
         ):
             value._serialized_on_wire = True
-    
+
         if attr != "_serialized_on_wire":
             # Track when a field has been set.
             self.__dict__["_serialized_on_wire"] = True
@@ -1483,7 +1483,6 @@ class Message(ABC):
         field_name_to_meta = cls._betterproto_meta.meta_by_field_name  # type: ignore
 
         for group, field_set in group_to_one_ofs.items():
-
             if len(field_set) == 1:
                 (field,) = field_set
                 field_name = field.name

--- a/tests/inputs/google_impl_behavior_equivalence/google_impl_behavior_equivalence.proto
+++ b/tests/inputs/google_impl_behavior_equivalence/google_impl_behavior_equivalence.proto
@@ -2,14 +2,16 @@ syntax = "proto3";
 
 package google_impl_behavior_equivalence;
 
-message Foo{
-  int64 bar = 1;
-}
+message Foo { int64 bar = 1; }
 
-message Test{
-  oneof group{
+message Test {
+  oneof group {
     string string = 1;
     int64 integer = 2;
     Foo foo = 3;
   }
 }
+
+message Request { Empty foo = 1; }
+
+message Empty {}

--- a/tests/inputs/google_impl_behavior_equivalence/test_google_impl_behavior_equivalence.py
+++ b/tests/inputs/google_impl_behavior_equivalence/test_google_impl_behavior_equivalence.py
@@ -5,10 +5,14 @@ import betterproto
 from tests.output_betterproto.google_impl_behavior_equivalence import (
     Foo,
     Test,
+    Request,
+    Empty
 )
 from tests.output_reference.google_impl_behavior_equivalence.google_impl_behavior_equivalence_pb2 import (
     Foo as ReferenceFoo,
     Test as ReferenceTest,
+    Request as ReferenceRequest,
+    Empty as ReferenceEmpty,
 )
 
 
@@ -53,3 +57,16 @@ def test_bytes_are_the_same_for_oneof():
 
     assert isinstance(message_reference.foo, ReferenceFoo)
     assert isinstance(message_reference2.foo, ReferenceFoo)
+
+
+def test_empty_message_field():
+    message = Request()
+    reference_message = ReferenceFoo()
+
+    message.foo = Empty()
+    reference_message.foo.CopyFrom(ReferenceEmpty())
+
+    assert betterproto.serialized_on_wire(message.foo)
+    assert reference_message.HasField("foo")
+
+    assert bytes(message) == reference_message.SerializeToString()

--- a/tests/inputs/google_impl_behavior_equivalence/test_google_impl_behavior_equivalence.py
+++ b/tests/inputs/google_impl_behavior_equivalence/test_google_impl_behavior_equivalence.py
@@ -3,21 +3,20 @@ from google.protobuf import json_format
 
 import betterproto
 from tests.output_betterproto.google_impl_behavior_equivalence import (
+    Empty,
     Foo,
-    Test,
     Request,
-    Empty
+    Test,
 )
 from tests.output_reference.google_impl_behavior_equivalence.google_impl_behavior_equivalence_pb2 import (
-    Foo as ReferenceFoo,
-    Test as ReferenceTest,
-    Request as ReferenceRequest,
     Empty as ReferenceEmpty,
+    Foo as ReferenceFoo,
+    Request as ReferenceRequest,
+    Test as ReferenceTest,
 )
 
 
 def test_oneof_serializes_similar_to_google_oneof():
-
     tests = [
         (Test(string="abc"), ReferenceTest(string="abc")),
         (Test(integer=2), ReferenceTest(integer=2)),
@@ -34,7 +33,6 @@ def test_oneof_serializes_similar_to_google_oneof():
 
 
 def test_bytes_are_the_same_for_oneof():
-
     message = Test(string="")
     message_reference = ReferenceTest(string="")
 
@@ -61,7 +59,7 @@ def test_bytes_are_the_same_for_oneof():
 
 def test_empty_message_field():
     message = Request()
-    reference_message = ReferenceFoo()
+    reference_message = ReferenceRequest()
 
     message.foo = Empty()
     reference_message.foo.CopyFrom(ReferenceEmpty())


### PR DESCRIPTION
Closes #479 by attempting to set the serialization state upon setting the attribute. I am not familiar with this codebase however I believe this should work properly, and does from my testing.

For context, the previous approach only set the serialisation state to be truthy when an attribute of this "child" message was updated. This does not work for empty message structures so it needs to be set when the new object is assigned instead. 