### PR TITLE
Fix pydict serialization for optional fields

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1373,6 +1373,9 @@ class Message(ABC):
                     value = [i.to_pydict(casing, include_default_values) for i in value]
                     if value or include_default_values:
                         output[cased_name] = value
+                elif value is None:
+                    if include_default_values:
+                        output[cased_name] = None
                 elif (
                     value._serialized_on_wire
                     or include_default_values

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -265,6 +265,32 @@ def test_optional_flag():
     assert Request().parse(b"\n\x00").flag is False
 
 
+def test_optional_datetime_to_dict():
+    @dataclass
+    class Request(betterproto.Message):
+        date: Optional[datetime] = betterproto.message_field(1, optional=True)
+
+    # Check dict serialization
+    assert Request().to_dict() == {}
+    assert Request().to_dict(include_default_values=True) == {"date": None}
+    assert Request(date=datetime(2020, 1, 1)).to_dict() == {
+        "date": "2020-01-01T00:00:00Z"
+    }
+    assert Request(date=datetime(2020, 1, 1)).to_dict(include_default_values=True) == {
+        "date": "2020-01-01T00:00:00Z"
+    }
+
+    # Check pydict serialization
+    assert Request().to_pydict() == {}
+    assert Request().to_pydict(include_default_values=True) == {"date": None}
+    assert Request(date=datetime(2020, 1, 1)).to_pydict() == {
+        "date": datetime(2020, 1, 1)
+    }
+    assert Request(date=datetime(2020, 1, 1)).to_pydict(
+        include_default_values=True
+    ) == {"date": datetime(2020, 1, 1)}
+
+
 def test_to_json_default_values():
     @dataclass
     class TestMessage(betterproto.Message):


### PR DESCRIPTION
## What

Adds a block in `Mesaage.to_pydict` that explicitly checks for `None` values and assigns them to the dict if `include_default_values=True`.

## Why

Fixes #475 where `to_pydict` fails on optional fields with the error:

```
  File "...", in <listcomp>
    json.dump([f.to_pydict(casing=Casing.SNAKE, include_default_values=True) for f in frames], file)
  File "...\Python\Python310\lib\site-packages\betterproto\__init__.py", line 1365, in to_pydict
    output[cased_name] = value.to_pydict(casing, include_default_values)
  File "...\Python\Python310\lib\site-packages\betterproto\__init__.py", line 1359, in to_pydict
    value._serialized_on_wire
AttributeError: 'NoneType' object has no attribute '_serialized_on_wire'
```

## Testing

Added a test case that checks `to_pydict` and `to_dict` output when passing the message value and not, and when passing `include_default_values` and not. 