### PR TITLE
server-streaming: remove unreachable code from ServiceBase

### DIFF
--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -199,9 +199,6 @@ class {{ service.py_name }}Base(ServiceBase):
 
         {% endif %}
         raise grpclib.GRPCError(grpclib.const.Status.UNIMPLEMENTED)
-        {% if method.server_streaming %}
-        yield {{ method.py_output_message_type }}()
-        {% endif %}
 
     {% endfor %}
 


### PR DESCRIPTION
example output:
```
class UsersBase(ServiceBase):
    async def get_users(
        self, get_users_request: "GetUsersRequest"
    ) -> "GetUsersResponse":
        raise grpclib.GRPCError(grpclib.const.Status.UNIMPLEMENTED)

    async def get_users_stream(
        self, get_users_request: "GetUsersRequest"
    ) -> AsyncIterator["User"]:
        raise grpclib.GRPCError(grpclib.const.Status.UNIMPLEMENTED)
        yield User() # removed this
```