### PR TITLE
Dont set `group` for optional fields

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -930,7 +930,7 @@ class Message(ABC):
             # Note that proto3 field presence/optional fields are put in a
             # synthetic single-item oneof by protoc, which helps us ensure we
             # send the value even if the value is the default zero value.
-            selected_in_group = bool(meta.group)
+            selected_in_group = bool(meta.group) or meta.optional
 
             # Empty messages can still be sent on the wire if they were
             # set (or received empty).

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -385,7 +385,7 @@ def is_oneof(proto_field_obj: FieldDescriptorProto) -> bool:
         us to tell whether it was set, via the which_one_of interface.
     """
 
-    return which_one_of(proto_field_obj, "oneof_index")[0] == "oneof_index"
+    return not proto_field_obj.proto3_optional and which_one_of(proto_field_obj, "oneof_index")[0] == "oneof_index"
 
 
 @dataclass

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -385,7 +385,10 @@ def is_oneof(proto_field_obj: FieldDescriptorProto) -> bool:
         us to tell whether it was set, via the which_one_of interface.
     """
 
-    return not proto_field_obj.proto3_optional and which_one_of(proto_field_obj, "oneof_index")[0] == "oneof_index"
+    return (
+        not proto_field_obj.proto3_optional
+        and which_one_of(proto_field_obj, "oneof_index")[0] == "oneof_index"
+    )
 
 
 @dataclass


### PR DESCRIPTION
When parsing `.proto` files, `protoc` makes each optional field part of a distinct group. This is probably for backwards compatibility since the proto3 optional feature was only added later. Since betterproto supports this feature, it seems natural to me to ignore these artificial group names of optional fields. This change also fixes #523.