### PR TITLE
Add one-of `match` example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,22 @@ message Test {
 }
 ```
 
-You can use `betterproto.which_one_of(message, group_name)` to determine which of the fields was set. It returns a tuple of the field name and value, or a blank string and `None` if unset.
+On Python 3.10 and later, you can use a `match` statement to access the provided one-of field, which supports type-checking:
+
+```py
+test = Test()
+match test:
+    case Test(on=value):
+        print(value)  # value: bool
+    case Test(count=value):
+        print(value)  # value: int
+    case Test(name=value):
+        print(value)  # value: str
+    case _:
+        print("No value provided")
+```
+
+You can also use `betterproto.which_one_of(message, group_name)` to determine which of the fields was set. It returns a tuple of the field name and value, or a blank string and `None` if unset.
 
 ```py
 >>> test = Test()
@@ -292,17 +307,11 @@ You can use `betterproto.which_one_of(message, group_name)` to determine which o
 >>> test.count = 57
 >>> betterproto.which_one_of(test, "foo")
 ["count", 57]
->>> test.on
-False
 
 # Default (zero) values also work.
 >>> test.name = ""
 >>> betterproto.which_one_of(test, "foo")
 ["name", ""]
->>> test.count
-0
->>> test.on
-False
 ```
 
 Again this is a little different than the official Google code generator:


### PR DESCRIPTION
Removed the parts of the example that showed accessing an unset value, as it now raises an `AttributeError`, and added an example of the `match` way of accessing the attributes.

Related to #510 and #358.

## Summary

Update documentation related to one-of fields and using a `match` statement to read it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
 
