### PR TITLE
tests: add an encoding roundtrip for Struct

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -55,7 +55,6 @@ from .utils import (
     hybridmethod,
 )
 
-
 if TYPE_CHECKING:
     from _typeshed import (
         SupportsRead,

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -17,6 +17,11 @@ def test_struct_roundtrip():
     assert struct_from_dict.to_dict() == data
     assert struct_from_dict.to_json() == data_json
 
+    struct_from_proto = Struct().parse(bytes(struct_from_dict))
+    assert struct_from_proto.fields == data
+    assert struct_from_proto.to_dict() == data
+    assert struct_from_proto.to_json() == data_json
+
     struct_from_json = Struct().from_json(data_json)
     assert struct_from_json.fields == data
     assert struct_from_json.to_dict() == data


### PR DESCRIPTION
## Summary

Follows #551. This currently fails, as expected, since `dump()` is not correctly specialized for `Struct`.

This is a work in progress.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [x] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
 
