### PR TITLE
Use identity check with PLACEHOLDER instead of equality test

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -749,7 +749,7 @@ class Message(ABC):
                 group_current.setdefault(meta.group)
 
             value = self.__raw_get(field_name)
-            if value != PLACEHOLDER and not (meta.optional and value is None):
+            if value is not PLACEHOLDER and not (meta.optional and value is None):
                 # Found a non-sentinel value
                 all_sentinel = False
 


### PR DESCRIPTION
## Summary
PLACEHOLDER is a specific instance of a sentinel object, the test here should be identity instead of equality, i.e. "is not" instead of "!="
I am experimenting with adding ndarray support, and the equality test here causes problems.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
 
