### PR TITLE
Add betterproto.Enum __copy__ and __deepcopy__ implementations

### DIFF
--- a/src/betterproto/enum.py
+++ b/src/betterproto/enum.py
@@ -159,7 +159,7 @@ class Enum(IntEnum if TYPE_CHECKING else int, metaclass=EnumType):
     def __copy__(self) -> Self:
         return self
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: Any) -> Self:
         return self
 
     @classmethod

--- a/src/betterproto/enum.py
+++ b/src/betterproto/enum.py
@@ -156,6 +156,12 @@ class Enum(IntEnum if TYPE_CHECKING else int, metaclass=EnumType):
             f"{self.__class__.__name__} Cannot delete a member's attributes."
         )
 
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo):
+        return self
+
     @classmethod
     def try_value(cls, value: int = 0) -> Self:
         """Return the value which corresponds to the value.

--- a/src/betterproto/enum.py
+++ b/src/betterproto/enum.py
@@ -156,7 +156,7 @@ class Enum(IntEnum if TYPE_CHECKING else int, metaclass=EnumType):
             f"{self.__class__.__name__} Cannot delete a member's attributes."
         )
 
-    def __copy__(self):
+    def __copy__(self) -> Self:
         return self
 
     def __deepcopy__(self, memo):


### PR DESCRIPTION
## Summary

betterproto.Enum is missing __copy__ and __deepcopy__ implementations, which were recently added to enum.Enum, see https://github.com/python/cpython/issues/106602 This fixes the bug where betterproto messages with Enums nested within cannot be copied via copy.deepcopy.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
 
