### PR TITLE
`betterproto-rust-codec` updated

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -99,22 +99,22 @@ files = [
 
 [[package]]
 name = "betterproto-rust-codec"
-version = "0.1.0"
+version = "0.1.1"
 description = "Fast conversion between betterproto messages and Protobuf wire format."
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "betterproto_rust_codec-0.1.0-cp37-abi3-macosx_10_7_x86_64.whl", hash = "sha256:3e7bea088f5f630cf123b56b1e1da7b35a22a295561825dd7c1446fa841876c3"},
-    {file = "betterproto_rust_codec-0.1.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:d1706da37a162d72de557ae3e285d04bb66cf129584d380439266e6e0d60c70a"},
-    {file = "betterproto_rust_codec-0.1.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:07aeb3471e9ea3f142f79673b1057810a133c8285aa0a606c53a43a3e28c37da"},
-    {file = "betterproto_rust_codec-0.1.0-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4b905251be0eae0e7605ecf4a2d60f8c54f3a3c5e6d1d732a0060a18d69cf5e4"},
-    {file = "betterproto_rust_codec-0.1.0-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c82353cd2a53f0ced0546d94dd5b18026eed1231a7658e6d5876cc09b1cfdae8"},
-    {file = "betterproto_rust_codec-0.1.0-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5b881d5a54e8ac7a898fc7f27971e91a6596d344faf342a262cecfa5b1f0dc1a"},
-    {file = "betterproto_rust_codec-0.1.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fc2d2d11d62a91b75d94783518563673972ad2c99bee9fd16176d3cd4c15d76"},
-    {file = "betterproto_rust_codec-0.1.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1f9b99f776ce1da52f83715b926b61f2ad52fdf1e6d7dec0aea5fb471cd468b1"},
-    {file = "betterproto_rust_codec-0.1.0-cp37-abi3-win32.whl", hash = "sha256:2f98155920ff409551208820224ac62564e8dd89d7caed86f8cd519fc7e05568"},
-    {file = "betterproto_rust_codec-0.1.0-cp37-abi3-win_amd64.whl", hash = "sha256:8e32f75cf59d5faaa5efb00c268fa22f47def0855c3395e5accccf296b2243be"},
-    {file = "betterproto_rust_codec-0.1.0.tar.gz", hash = "sha256:090c23accb23e8f167dabab6fab70d30ae20f587e677c2da4a88982c5fafc5d1"},
+    {file = "betterproto_rust_codec-0.1.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:38ec2ec1743d815a04ffc020e8e3791955601b239b097e4ae0721528d4d8b608"},
+    {file = "betterproto_rust_codec-0.1.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:96a6deef8cda4b4d084df98b621e39a3123d8878dab551b86bbe733d885c4965"},
+    {file = "betterproto_rust_codec-0.1.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:72ce9f153c83b1d0559ab40b0d6a31d8b83ac486230cefc298c8a08f4a97738b"},
+    {file = "betterproto_rust_codec-0.1.1-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b8a8485aabbe843208307a9a2c3fc8a8c09295fb22c840cebd5fa7ec6b8ddb36"},
+    {file = "betterproto_rust_codec-0.1.1-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:22a395bf0c9dc86b7d3783ba43f161cd9f7a42809f38c70673cd9999d40eb4f1"},
+    {file = "betterproto_rust_codec-0.1.1-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea99bee659b33500bb1afc4e0dbfa63530f50a7c549d0687565a10a0de63d18f"},
+    {file = "betterproto_rust_codec-0.1.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:913d73365780d8f3da04cbaa1b2428ca5dc5372a5ee6f4ff2b9f30127362dff7"},
+    {file = "betterproto_rust_codec-0.1.1-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a16dbbbc48f4a27b3b70205a2a71baa53fe0e915bc347b75d9b3864326446fa"},
+    {file = "betterproto_rust_codec-0.1.1-cp37-abi3-win32.whl", hash = "sha256:06f95ac4c92aa1f28bd1be884c6db86f0bed05c9b93a1e4e3d80bbe2fc66847c"},
+    {file = "betterproto_rust_codec-0.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:5b70b3aea76f336cc243b966f2f7496cb6366ad2679d7a999ff521d873f9de48"},
+    {file = "betterproto_rust_codec-0.1.1.tar.gz", hash = "sha256:6f7cbe80c8e3f87df992d71568771082c869ed6856521e01db833d9d3b012af5"},
 ]
 
 [[package]]
@@ -1501,6 +1501,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1929,4 +1930,4 @@ rust-codec = ["betterproto-rust-codec"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "0e0d9fe748a60b22a7147e05c7940ffcad6facb7554cc1ad791e58f4a4c5c22d"
+content-hash = "7c54aedaa1ada11965ce6fd5d3e0adffc0a9adf2e12fca667b5db5ffac2db568"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ jinja2 = { version = ">=3.0.3", optional = true }
 python-dateutil = "^2.8"
 isort = {version = "^5.11.5", optional = true}
 typing-extensions = "^4.7.1"
-betterproto-rust-codec = { version = "0.1.0", optional = true }
+betterproto-rust-codec = { version = "0.1.1", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 asv = "^0.4.2"


### PR DESCRIPTION
`betterproto-rust-codec` is updated from 0.1.0 to 0.1.1. This update includes:
* dependency updates (most noteworthy PyO3 0.20 -> 0.21)
  * implicitly fixing [this bug](https://github.com/124C41p/betterproto-rust-codec/issues/2)
* (de-)serialization of timestamps and durations improved
  * fixing [precision loss for large timedeltas](https://github.com/124C41p/betterproto-rust-codec/issues/4)
* improved error messages

See [the corresponding PR](https://github.com/124C41p/betterproto-rust-codec/pull/3) for more details.