### PR TITLE
Output INT_64_TYPES as int instead of string in to_dict

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1477,12 +1477,12 @@ class Message(ABC):
             ):
                 if meta.proto_type in INT_64_TYPES:
                     if field_is_repeated:
-                        output[cased_name] = [str(n) for n in value]
+                        output[cased_name] = [int(n) for n in value]
                     elif value is None:
                         if include_default_values:
                             output[cased_name] = value
                     else:
-                        output[cased_name] = str(value)
+                        output[cased_name] = int(value)
                 elif meta.proto_type == TYPE_BYTES:
                     if field_is_repeated:
                         output[cased_name] = [

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1476,13 +1476,20 @@ class Message(ABC):
                 )
             ):
                 if meta.proto_type in INT_64_TYPES:
+                    system_64_bit = sys.maxsize > 2**32
                     if field_is_repeated:
-                        output[cased_name] = [int(n) for n in value]
+                        if system_64_bit:
+                            output[cased_name] = [int(n) for n in value]
+                        else:
+                            output[cased_name] = [str(n) for n in value]
                     elif value is None:
                         if include_default_values:
                             output[cased_name] = value
                     else:
-                        output[cased_name] = int(value)
+                        if system_64_bit:
+                            output[cased_name] = int(value)
+                        else:
+                            output[cased_name] = str(value)
                 elif meta.proto_type == TYPE_BYTES:
                     if field_is_repeated:
                         output[cased_name] = [


### PR DESCRIPTION
## Summary

Previous behavior was int64 fields would be represented as strings when `to_dict` was called, when they should really be represented as ints, at least on 64 bit machines. 

Short term fix is to use int32 instead
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
 
