### PR TITLE
Fix 'typing' import collisions.

### DIFF
--- a/src/betterproto/compile/importing.py
+++ b/src/betterproto/compile/importing.py
@@ -57,7 +57,7 @@ def get_type_reference(
     if unwrap:
         if source_type in WRAPPER_TYPES:
             wrapped_type = type(WRAPPER_TYPES[source_type]().value)
-            return f"Optional[{wrapped_type.__name__}]"
+            return f"typing.Optional[{wrapped_type.__name__}]"
 
         if source_type == ".google.protobuf.Duration":
             return "timedelta"

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -29,7 +29,6 @@ instantiating field `A` with parent message `B` should add a
 reference to `A` to `B`'s `fields` attribute.
 """
 
-
 import builtins
 import re
 import textwrap
@@ -319,7 +318,7 @@ class MessageCompiler(ProtoContentBase):
     @property
     def annotation(self) -> str:
         if self.repeated:
-            return f"List[{self.py_name}]"
+            return f"typing.List[{self.py_name}]"
         return self.py_name
 
     @property
@@ -438,11 +437,11 @@ class FieldCompiler(MessageCompiler):
     def typing_imports(self) -> Set[str]:
         imports = set()
         annotation = self.annotation
-        if "Optional[" in annotation:
+        if "typing.Optional[" in annotation:
             imports.add("Optional")
-        if "List[" in annotation:
+        if "typing.List[" in annotation:
             imports.add("List")
-        if "Dict[" in annotation:
+        if "typing.Dict[" in annotation:
             imports.add("Dict")
         return imports
 
@@ -488,7 +487,7 @@ class FieldCompiler(MessageCompiler):
     @property
     def mutable(self) -> bool:
         """True if the field is a mutable type, otherwise False."""
-        return self.annotation.startswith(("List[", "Dict["))
+        return self.annotation.startswith(("typing.List[", "typing.Dict["))
 
     @property
     def field_type(self) -> str:
@@ -573,9 +572,9 @@ class FieldCompiler(MessageCompiler):
         if self.use_builtins:
             py_type = f"builtins.{py_type}"
         if self.repeated:
-            return f"List[{py_type}]"
+            return f"typing.List[{py_type}]"
         if self.optional:
-            return f"Optional[{py_type}]"
+            return f"typing.Optional[{py_type}]"
         return py_type
 
 
@@ -645,7 +644,7 @@ class MapEntryCompiler(FieldCompiler):
 
     @property
     def annotation(self) -> str:
-        return f"Dict[{self.py_k_type}, {self.py_v_type}]"
+        return f"typing.Dict[{self.py_k_type}, {self.py_v_type}]"
 
     @property
     def repeated(self) -> bool:

--- a/src/betterproto/plugin/parser.py
+++ b/src/betterproto/plugin/parser.py
@@ -94,9 +94,9 @@ def generate_code(request: CodeGeneratorRequest) -> CodeGeneratorResponse:
             request_data.output_packages[output_package_name].output = False
 
         if "pydantic_dataclasses" in plugin_options:
-            request_data.output_packages[
-                output_package_name
-            ].pydantic_dataclasses = True
+            request_data.output_packages[output_package_name].pydantic_dataclasses = (
+                True
+            )
 
     # Read Messages and Enums
     # We need to read Messages before Services in so that we can

--- a/src/betterproto/plugin/parser.py
+++ b/src/betterproto/plugin/parser.py
@@ -94,9 +94,9 @@ def generate_code(request: CodeGeneratorRequest) -> CodeGeneratorResponse:
             request_data.output_packages[output_package_name].output = False
 
         if "pydantic_dataclasses" in plugin_options:
-            request_data.output_packages[output_package_name].pydantic_dataclasses = (
-                True
-            )
+            request_data.output_packages[
+                output_package_name
+            ].pydantic_dataclasses = True
 
     # Read Messages and Enums
     # We need to read Messages before Services in so that we can

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -21,8 +21,7 @@ from datetime import {% for i in output_file.datetime_imports|sort %}{{ i }}{% i
 
 {% endif%}
 {% if output_file.typing_imports %}
-from typing import {% for i in output_file.typing_imports|sort %}{{ i }}{% if not loop.last %}, {% endif %}{% endfor %}
-
+import typing
 {% endif %}
 
 {% if output_file.pydantic_imports %}
@@ -120,9 +119,9 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
         {%- endif -%}
             ,
             *
-            , timeout: Optional[float] = None
-            , deadline: Optional["Deadline"] = None
-            , metadata: Optional["MetadataLike"] = None
+            , timeout: typing.Optional[float] = None
+            , deadline: typing.Optional["Deadline"] = None
+            , metadata: typing.Optional["MetadataLike"] = None
             ) -> {% if method.server_streaming %}AsyncIterator["{{ method.py_output_message_type }}"]{% else %}"{{ method.py_output_message_type }}"{% endif %}:
         {% if method.comment %}
 {{ method.comment }}
@@ -225,7 +224,7 @@ class {{ service.py_name }}Base(ServiceBase):
 
     {% endfor %}
 
-    def __mapping__(self) -> Dict[str, grpclib.const.Handler]:
+    def __mapping__(self) -> typing.Dict[str, grpclib.const.Handler]:
         return {
         {% for method in service.methods %}
         "{{ method.route }}": grpclib.const.Handler(

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -115,14 +115,14 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
             {%- if method.py_input_message -%}, {{ method.py_input_message_param }}: "{{ method.py_input_message_type }}"{%- endif -%}
         {%- else -%}
             {# Client streaming: need a request iterator instead #}
-            , {{ method.py_input_message_param }}_iterator: Union[AsyncIterable["{{ method.py_input_message_type }}"], Iterable["{{ method.py_input_message_type }}"]]
+            , {{ method.py_input_message_param }}_iterator: typing.Union[typing.AsyncIterable["{{ method.py_input_message_type }}"], typing.Iterable["{{ method.py_input_message_type }}"]]
         {%- endif -%}
             ,
             *
             , timeout: typing.Optional[float] = None
             , deadline: typing.Optional["Deadline"] = None
             , metadata: typing.Optional["MetadataLike"] = None
-            ) -> {% if method.server_streaming %}AsyncIterator["{{ method.py_output_message_type }}"]{% else %}"{{ method.py_output_message_type }}"{% endif %}:
+            ) -> {% if method.server_streaming %}typing.AsyncIterator["{{ method.py_output_message_type }}"]{% else %}"{{ method.py_output_message_type }}"{% endif %}:
         {% if method.comment %}
 {{ method.comment }}
 
@@ -190,9 +190,9 @@ class {{ service.py_name }}Base(ServiceBase):
             {%- if method.py_input_message -%}, {{ method.py_input_message_param }}: "{{ method.py_input_message_type }}"{%- endif -%}
         {%- else -%}
             {# Client streaming: need a request iterator instead #}
-            , {{ method.py_input_message_param }}_iterator: AsyncIterator["{{ method.py_input_message_type }}"]
+            , {{ method.py_input_message_param }}_iterator: typing.AsyncIterator["{{ method.py_input_message_type }}"]
         {%- endif -%}
-            ) -> {% if method.server_streaming %}AsyncIterator["{{ method.py_output_message_type }}"]{% else %}"{{ method.py_output_message_type }}"{% endif %}:
+            ) -> {% if method.server_streaming %}typing.AsyncIterator["{{ method.py_output_message_type }}"]{% else %}"{{ method.py_output_message_type }}"{% endif %}:
         {% if method.comment %}
 {{ method.comment }}
 

--- a/tests/test_get_ref_type.py
+++ b/tests/test_get_ref_type.py
@@ -87,15 +87,15 @@ def test_reference_google_wellknown_types_non_wrappers_pydantic(
 @pytest.mark.parametrize(
     ["google_type", "expected_name"],
     [
-        (".google.protobuf.DoubleValue", "Optional[float]"),
-        (".google.protobuf.FloatValue", "Optional[float]"),
-        (".google.protobuf.Int32Value", "Optional[int]"),
-        (".google.protobuf.Int64Value", "Optional[int]"),
-        (".google.protobuf.UInt32Value", "Optional[int]"),
-        (".google.protobuf.UInt64Value", "Optional[int]"),
-        (".google.protobuf.BoolValue", "Optional[bool]"),
-        (".google.protobuf.StringValue", "Optional[str]"),
-        (".google.protobuf.BytesValue", "Optional[bytes]"),
+        (".google.protobuf.DoubleValue", "typing.Optional[float]"),
+        (".google.protobuf.FloatValue", "typing.Optional[float]"),
+        (".google.protobuf.Int32Value", "typing.Optional[int]"),
+        (".google.protobuf.Int64Value", "typing.Optional[int]"),
+        (".google.protobuf.UInt32Value", "typing.Optional[int]"),
+        (".google.protobuf.UInt64Value", "typing.Optional[int]"),
+        (".google.protobuf.BoolValue", "typing.Optional[bool]"),
+        (".google.protobuf.StringValue", "typing.Optional[str]"),
+        (".google.protobuf.BytesValue", "typing.Optional[bytes]"),
     ],
 )
 def test_referenceing_google_wrappers_unwraps_them(


### PR DESCRIPTION
## Summary

The Kubernetes protobuf library contains a top level `List` [object](https://github.com/kubernetes/apimachinery/blob/703232ea6da48aed7ac22260dabc6eac01aab896/pkg/api/meta/interfaces.go#L33), which collided with the `typing.List` import in the top of each file. This resulted in the following error at import time, input sanitized:

```
Traceback (most recent call last):
...
    from ...k8s.io.api.core import v1 as __k8_s_io_api_core_v1__
  File "/.../k8s/io/api/core/v1/__init__.py", line 16, in <module>
    from ....apimachinery.pkg.apis.meta import v1 as ___apimachinery_pkg_apis_meta_v1__
  File "/.../k8s/io/apimachinery/pkg/apis/meta/v1/__init__.py", line 797, in <module>
    class ObjectMeta(betterproto.Message):
  File "/.../k8s/io/apimachinery/pkg/apis/meta/v1/__init__.py", line 931, in ObjectMeta
    owner_references: List["OwnerReference"] = betterproto.message_field(13)
                      ~~~~^^^^^^^^^^^^^^^^^^
TypeError: type 'List' is not subscriptable
```

This change makes the typing import a static import, and the fields keep the `typing.[Object]` qualifier, rather than having the `from typing import [Object]` import at the top of the file.

This results in usable libraries, where previously we were not able to import them.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
 
## Test Results

```
❯ poe test                     
Poe => pytest
============================================ test session starts ============================================
platform darwin -- Python 3.11.7, pytest-6.2.5, py-1.11.0, pluggy-1.2.0
rootdir: /.../python-betterproto, configfile: pytest.ini
plugins: cov-2.12.1, asyncio-0.12.0, mock-3.11.1
collected 699 items                                                                                         

tests/test_casing.py ........................................................................         [ 10%]
tests/test_deprecated.py ....                                                                         [ 10%]
tests/test_enum.py .................                                                                  [ 13%]
tests/test_features.py .....................                                                          [ 16%]
tests/test_get_ref_type.py ....................................................                       [ 23%]
tests/test_inputs.py .....X......X..x...................x...........X.........X......X..x............ [ 35%]
.......x...........X........X....x....................x.................x....x....................x.. [ 49%]
                                                                                                      [ 49%]
tests/test_mapmessage.py .                                                                            [ 49%]
tests/test_pickling.py .....                                                                          [ 50%]
tests/test_streams.py ............................                                                    [ 54%]
tests/test_struct.py .                                                                                [ 54%]
tests/test_timestamp.py ....                                                                          [ 55%]
tests/test_version.py .                                                                               [ 55%]
tests/grpc/test_grpclib_client.py ..............                                                      [ 57%]
tests/grpc/test_stream_stream.py .....                                                                [ 58%]
tests/inputs/bool/test_bool.py ...                                                                    [ 58%]
tests/inputs/casing/test_casing.py ...                                                                [ 58%]
tests/inputs/casing_inner_class/test_casing_inner_class.py ..                                         [ 59%]
tests/inputs/enum/test_enum.py ...........                                                            [ 60%]
tests/inputs/example_service/test_example_service.py .                                                [ 60%]
tests/inputs/google_impl_behavior_equivalence/test_google_impl_behavior_equivalence.py ....           [ 61%]
tests/inputs/googletypes_request/test_googletypes_request.py ...........                              [ 63%]
tests/inputs/googletypes_response/test_googletypes_response.py .........xxxxxxxxx                     [ 65%]
tests/inputs/googletypes_response_embedded/test_googletypes_response_embedded.py .                    [ 65%]
tests/inputs/import_service_input_message/test_import_service_input_message.py ...                    [ 66%]
tests/inputs/nestedtwice/test_nestedtwice.py ......                                                   [ 67%]
tests/inputs/oneof/test_oneof.py ....x                                                                [ 67%]
tests/inputs/oneof_default_value_serialization/test_oneof_default_value_serialization.py ...          [ 68%]
tests/inputs/oneof_enum/test_oneof_enum.py ...                                                        [ 68%]
tests/inputs/proto3_field_presence/test_proto3_field_presence.py ..                                   [ 68%]
tests/inputs/proto3_field_presence_oneof/test_proto3_field_presence_oneof.py .                        [ 69%]
tests/inputs/regression_387/test_regression_387.py .                                                  [ 69%]
tests/inputs/regression_414/test_regression_414.py .                                                  [ 69%]
tests/inputs/repeated_duration_timestamp/test_repeated_duration_timestamp.py .                        [ 69%]
tests/inputs/service_uppercase/test_service.py .                                                      [ 69%]
tests/inputs/timestamp_dict_encode/test_timestamp_dict_encode.py .................................... [ 74%]
..................................................................................................... [ 89%]
...........................................................................                           [100%]

================================ 673 passed, 19 xfailed, 7 xpassed in 5.73s =================================
```
