### PR TITLE
Add prefixed enums in addition to pretty ones

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1576,10 +1576,13 @@ class Message(ABC):
                     )
                 elif meta.proto_type == TYPE_ENUM:
                     enum_cls = cls._betterproto.cls_by_field[field_name]
+
+                    def obj(enum_class, value):
+                        return enum_class.from_full_name(value) if hasattr(enum_class, 'from_full_name') else enum_class.from_string(value)
                     if isinstance(value, list):
-                        value = [enum_cls.from_string(e) for e in value]
+                        value = [obj(enum_cls, e) for e in value]
                     elif isinstance(value, str):
-                        value = enum_cls.from_string(value)
+                        value = obj(enum_cls, value)
                 elif meta.proto_type in (TYPE_FLOAT, TYPE_DOUBLE):
                     value = (
                         [_parse_float(n) for n in value]

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1493,24 +1493,30 @@ class Message(ABC):
                     else:
                         output[cased_name] = b64encode(value).decode("utf8")
                 elif meta.proto_type == TYPE_ENUM:
+                    def name(enum_class, value):
+                        obj = enum_class(value)
+                        if hasattr(obj.__class__, 'full_name') and isinstance(obj.__class__.full_name, property):
+                            return obj.full_name
+                        return obj.name
                     if field_is_repeated:
                         enum_class = field_types[field_name].__args__[0]
                         if isinstance(value, typing.Iterable) and not isinstance(
                             value, str
                         ):
-                            output[cased_name] = [enum_class(el).name for el in value]
+                            output[cased_name] = [
+                                name(enum_class, el) for el in value]
                         else:
                             # transparently upgrade single value to repeated
-                            output[cased_name] = [enum_class(value).name]
+                            output[cased_name] = [name(enum_class, value)]
                     elif value is None:
                         if include_default_values:
                             output[cased_name] = value
                     elif meta.optional:
                         enum_class = field_types[field_name].__args__[0]
-                        output[cased_name] = enum_class(value).name
+                        output[cased_name] = name(enum_class, value)
                     else:
                         enum_class = field_types[field_name]  # noqa
-                        output[cased_name] = enum_class(value).name
+                        output[cased_name] = name(enum_class, value)
                 elif meta.proto_type in (TYPE_FLOAT, TYPE_DOUBLE):
                     if field_is_repeated:
                         output[cased_name] = [_dump_float(n) for n in value]

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -662,27 +662,19 @@ class EnumDefinitionCompiler(MessageCompiler):
     def __post_init__(self) -> None:
         # Get entries/allowed values for this Enum
         self.entries: List[self.EnumEntry] = []
-        for entry_number, entry_proto_value in enumerate(self.proto_obj.value):
-            pythonized_name = pythonize_enum_member_name(
-                entry_proto_value.name, self.proto_obj.name
-            )
-            name = sanitize_name(entry_proto_value.name)
-            entry = self.EnumEntry(
-                name=pythonized_name,
-                value=entry_proto_value.number,
+        self.entries = [
+            self.EnumEntry(
+                name=pythonize_enum_member_name(
+                    entry.name, self.proto_obj.name),
+                full_name=sanitize_name(entry.name),
+                value=entry.number,
                 comment=get_comment(
-                    proto_file=self.source_file, path=self.path + [2, entry_number]
-                ),
-            )
-            self.entries.append(entry)
-            if name != pythonized_name:
-                self.entries.append(
-                    self.EnumEntry(
-                        name=name,
-                        value=entry_proto_value.number,
-                        comment=entry.comment,
-                    )
+                    proto_file=self.source_file,
+                    path=self.path + [2, i]
                 )
+            )
+            for i, entry in enumerate(self.proto_obj.value)
+        ]
         super().__post_init__()  # call MessageCompiler __post_init__
 
     @property

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -662,19 +662,27 @@ class EnumDefinitionCompiler(MessageCompiler):
     def __post_init__(self) -> None:
         # Get entries/allowed values for this Enum
         self.entries: List[self.EnumEntry] = []
-        self.entries = [
-            self.EnumEntry(
-                name=pythonize_enum_member_name(
-                    entry.name, self.proto_obj.name),
-                full_name=sanitize_name(entry.name),
-                value=entry.number,
-                comment=get_comment(
-                    proto_file=self.source_file,
-                    path=self.path + [2, i]
-                )
+        for entry_number, entry_proto_value in enumerate(self.proto_obj.value):
+            pythonized_name = pythonize_enum_member_name(
+                entry_proto_value.name, self.proto_obj.name
             )
-            for i, entry in enumerate(self.proto_obj.value)
-        ]
+            name = sanitize_name(entry_proto_value.name)
+            entry = self.EnumEntry(
+                name=pythonized_name,
+                value=entry_proto_value.number,
+                comment=get_comment(
+                    proto_file=self.source_file, path=self.path + [2, entry_number]
+                ),
+            )
+            self.entries.append(entry)
+            if name != pythonized_name:
+                self.entries.append(
+                    self.EnumEntry(
+                        name=name,
+                        value=entry_proto_value.number,
+                        comment=entry.comment,
+                    )
+                )
         super().__post_init__()  # call MessageCompiler __post_init__
 
     @property

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -79,6 +79,7 @@ from .typing_compiler import (
     DirectImportTypingCompiler,
     TypingCompiler,
 )
+from ..casing import sanitize_name
 
 
 # Create a unique placeholder to deal with
@@ -660,18 +661,28 @@ class EnumDefinitionCompiler(MessageCompiler):
 
     def __post_init__(self) -> None:
         # Get entries/allowed values for this Enum
-        self.entries = [
-            self.EnumEntry(
-                name=pythonize_enum_member_name(
-                    entry_proto_value.name, self.proto_obj.name
-                ),
+        self.entries: List[self.EnumEntry] = []
+        for entry_number, entry_proto_value in enumerate(self.proto_obj.value):
+            pythonized_name = pythonize_enum_member_name(
+                entry_proto_value.name, self.proto_obj.name
+            )
+            name = sanitize_name(entry_proto_value.name)
+            entry = self.EnumEntry(
+                name=pythonized_name,
                 value=entry_proto_value.number,
                 comment=get_comment(
                     proto_file=self.source_file, path=self.path + [2, entry_number]
                 ),
             )
-            for entry_number, entry_proto_value in enumerate(self.proto_obj.value)
-        ]
+            self.entries.append(entry)
+            if name != pythonized_name:
+                self.entries.append(
+                    self.EnumEntry(
+                        name=name,
+                        value=entry_proto_value.number,
+                        comment=entry.comment,
+                    )
+                )
         super().__post_init__()  # call MessageCompiler __post_init__
 
     @property

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -65,6 +65,7 @@ from betterproto.lib.google.protobuf import (
 from betterproto.lib.google.protobuf.compiler import CodeGeneratorRequest
 
 from .. import which_one_of
+from ..casing import sanitize_name
 from ..compile.importing import (
     get_type_reference,
     parse_source_type_name,
@@ -655,6 +656,7 @@ class EnumDefinitionCompiler(MessageCompiler):
         """Representation of an Enum entry."""
 
         name: str
+        full_name: str
         value: int
         comment: str
 
@@ -665,6 +667,7 @@ class EnumDefinitionCompiler(MessageCompiler):
                 name=pythonize_enum_member_name(
                     entry_proto_value.name, self.proto_obj.name
                 ),
+                full_name=sanitize_name(entry_proto_value.name),
                 value=entry_proto_value.number,
                 comment=get_comment(
                     proto_file=self.source_file, path=self.path + [2, entry_number]

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -79,7 +79,6 @@ from .typing_compiler import (
     DirectImportTypingCompiler,
     TypingCompiler,
 )
-from ..casing import sanitize_name
 
 
 # Create a unique placeholder to deal with
@@ -661,28 +660,18 @@ class EnumDefinitionCompiler(MessageCompiler):
 
     def __post_init__(self) -> None:
         # Get entries/allowed values for this Enum
-        self.entries: List[self.EnumEntry] = []
-        for entry_number, entry_proto_value in enumerate(self.proto_obj.value):
-            pythonized_name = pythonize_enum_member_name(
-                entry_proto_value.name, self.proto_obj.name
-            )
-            name = sanitize_name(entry_proto_value.name)
-            entry = self.EnumEntry(
-                name=pythonized_name,
+        self.entries = [
+            self.EnumEntry(
+                name=pythonize_enum_member_name(
+                    entry_proto_value.name, self.proto_obj.name
+                ),
                 value=entry_proto_value.number,
                 comment=get_comment(
                     proto_file=self.source_file, path=self.path + [2, entry_number]
                 ),
             )
-            self.entries.append(entry)
-            if name != pythonized_name:
-                self.entries.append(
-                    self.EnumEntry(
-                        name=name,
-                        value=entry_proto_value.number,
-                        comment=entry.comment,
-                    )
-                )
+            for entry_number, entry_proto_value in enumerate(self.proto_obj.value)
+        ]
         super().__post_init__()  # call MessageCompiler __post_init__
 
     @property

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -20,6 +20,7 @@ class {{ enum.py_name }}(betterproto.Enum):
         return core_schema.int_schema(ge=0)
     {% endif %}
 
+    @property
     def full_name(self):
         return {{ enum.py_name }}_full_name_map[self.value]
 

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -24,9 +24,20 @@ class {{ enum.py_name }}(betterproto.Enum):
     def full_name(self):
         return {{ enum.py_name }}_full_name_map[self.value]
 
+    @classmethod
+    def from_full_name(cls, full_name):
+        return cls.from_string({{ enum.py_name }}_full_name_reverse_map[full_name])
+
+
 {{ enum.py_name }}_full_name_map = {
 {% for entry in enum.entries %}
     {{ entry.value }}: "{{ entry.full_name }}",
+{% endfor %}
+}
+
+{{ enum.py_name }}_full_name_reverse_map = {
+{% for entry in enum.entries %}
+    "{{ entry.full_name }}": "{{ entry.name }}",
 {% endfor %}
 }
 {% endfor %}

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -20,6 +20,14 @@ class {{ enum.py_name }}(betterproto.Enum):
         return core_schema.int_schema(ge=0)
     {% endif %}
 
+    def full_name(self):
+        return {{ enum.py_name }}_full_name_map[self.value]
+
+{{ enum.py_name }}_full_name_map = {
+{% for entry in enum.entries %}
+    {{ entry.value }}: "{{ entry.full_name }}",
+{% endfor %}
+}
 {% endfor %}
 {% endif %}
 {% for message in output_file.messages %}

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -20,14 +20,6 @@ class {{ enum.py_name }}(betterproto.Enum):
         return core_schema.int_schema(ge=0)
     {% endif %}
 
-    def full_name(self):
-        return {{ enum.py_name }}_full_name_map[self.value]
-
-{{ enum.py_name }}_full_name_map = {
-{% for entry in enum.entries %}
-    {{ entry.value }}: "{{ entry.full_name }}",
-{% endfor %}
-}
 {% endfor %}
 {% endif %}
 {% for message in output_file.messages %}

--- a/tests/inputs/enum/enum.proto
+++ b/tests/inputs/enum/enum.proto
@@ -6,6 +6,7 @@ package enum;
 message Test {
   Choice choice = 1;
   repeated Choice choices = 2;
+  ArithmeticOperator op = 3;
 }
 
 enum Choice {

--- a/tests/inputs/enum/test_enum.py
+++ b/tests/inputs/enum/test_enum.py
@@ -115,6 +115,6 @@ def test_renamed_enum_members():
 
 
 def test_enum_full_name():
-    assert ArithmeticOperator.NONE.full_name() == "ARITHMETIC_OPERATOR_NONE"
-    assert ArithmeticOperator.PLUS.full_name() == "ARITHMETIC_OPERATOR_PLUS"
-    assert ArithmeticOperator._0_PREFIXED.full_name() == "ARITHMETIC_OPERATOR_0_PREFIXED"
+    assert ArithmeticOperator.NONE.full_name == "ARITHMETIC_OPERATOR_NONE"
+    assert ArithmeticOperator.PLUS.full_name == "ARITHMETIC_OPERATOR_PLUS"
+    assert ArithmeticOperator._0_PREFIXED.full_name == "ARITHMETIC_OPERATOR_0_PREFIXED"

--- a/tests/inputs/enum/test_enum.py
+++ b/tests/inputs/enum/test_enum.py
@@ -105,14 +105,7 @@ def test_enum_mapped_on_parse():
     assert Test().choice.name == Choice.ZERO.name
 
 
-def test_renamed_enum_members():
-    assert set(ArithmeticOperator.__members__) == {
-        "NONE",
-        "PLUS",
-        "MINUS",
-        "_0_PREFIXED",
-        "ARITHMETIC_OPERATOR_NONE",
-        "ARITHMETIC_OPERATOR_PLUS",
-        "ARITHMETIC_OPERATOR_MINUS",
-        "ARITHMETIC_OPERATOR_0_PREFIXED",
-    }
+def test_enum_full_name():
+    assert ArithmeticOperator.NONE.full_name() == "ARITHMETIC_OPERATOR_NONE"
+    assert ArithmeticOperator.PLUS.full_name() == "ARITHMETIC_OPERATOR_PLUS"
+    assert ArithmeticOperator._0_PREFIXED.full_name() == "ARITHMETIC_OPERATOR_0_PREFIXED"

--- a/tests/inputs/enum/test_enum.py
+++ b/tests/inputs/enum/test_enum.py
@@ -111,4 +111,8 @@ def test_renamed_enum_members():
         "PLUS",
         "MINUS",
         "_0_PREFIXED",
+        "ARITHMETIC_OPERATOR_NONE",
+        "ARITHMETIC_OPERATOR_PLUS",
+        "ARITHMETIC_OPERATOR_MINUS",
+        "ARITHMETIC_OPERATOR_0_PREFIXED",
     }

--- a/tests/inputs/enum/test_enum.py
+++ b/tests/inputs/enum/test_enum.py
@@ -111,8 +111,4 @@ def test_renamed_enum_members():
         "PLUS",
         "MINUS",
         "_0_PREFIXED",
-        "ARITHMETIC_OPERATOR_NONE",
-        "ARITHMETIC_OPERATOR_PLUS",
-        "ARITHMETIC_OPERATOR_MINUS",
-        "ARITHMETIC_OPERATOR_0_PREFIXED",
     }

--- a/tests/inputs/enum/test_enum.py
+++ b/tests/inputs/enum/test_enum.py
@@ -1,3 +1,6 @@
+import betterproto
+from dataclasses import dataclass
+
 from tests.output_betterproto.enum import (
     ArithmeticOperator,
     Choice,
@@ -126,3 +129,22 @@ def test_enum_to_json():
     ) == '{"op": "ARITHMETIC_OPERATOR_PLUS"}'
     assert Test(op=ArithmeticOperator._0_PREFIXED).to_json(
     ) == '{"op": "ARITHMETIC_OPERATOR_0_PREFIXED"}'
+
+
+class EnumCompat(betterproto.Enum):
+    NONE = 0
+    PLUS = 1
+    MINUS = 2
+
+
+@dataclass(eq=False, repr=False)
+class CompatTest(betterproto.Message):
+    enum: "EnumCompat" = betterproto.enum_field(1)
+
+
+def test_enum_to_json_backwards_compat():
+    assert CompatTest(enum=EnumCompat.NONE).to_json() == '{}'
+    assert CompatTest(enum=EnumCompat.PLUS).to_json(
+    ) == '{"enum": "PLUS"}'
+    assert CompatTest(enum=EnumCompat.MINUS).to_json(
+    ) == '{"enum": "MINUS"}'

--- a/tests/inputs/enum/test_enum.py
+++ b/tests/inputs/enum/test_enum.py
@@ -112,3 +112,9 @@ def test_renamed_enum_members():
         "MINUS",
         "_0_PREFIXED",
     }
+
+
+def test_enum_full_name():
+    assert ArithmeticOperator.NONE.full_name() == "ARITHMETIC_OPERATOR_NONE"
+    assert ArithmeticOperator.PLUS.full_name() == "ARITHMETIC_OPERATOR_PLUS"
+    assert ArithmeticOperator._0_PREFIXED.full_name() == "ARITHMETIC_OPERATOR_0_PREFIXED"

--- a/tests/inputs/enum/test_enum.py
+++ b/tests/inputs/enum/test_enum.py
@@ -118,3 +118,11 @@ def test_enum_full_name():
     assert ArithmeticOperator.NONE.full_name == "ARITHMETIC_OPERATOR_NONE"
     assert ArithmeticOperator.PLUS.full_name == "ARITHMETIC_OPERATOR_PLUS"
     assert ArithmeticOperator._0_PREFIXED.full_name == "ARITHMETIC_OPERATOR_0_PREFIXED"
+
+
+def test_enum_to_json():
+    assert Test(op=ArithmeticOperator.NONE).to_json() == '{}'
+    assert Test(op=ArithmeticOperator.PLUS).to_json(
+    ) == '{"op": "ARITHMETIC_OPERATOR_PLUS"}'
+    assert Test(op=ArithmeticOperator._0_PREFIXED).to_json(
+    ) == '{"op": "ARITHMETIC_OPERATOR_0_PREFIXED"}'

--- a/tests/inputs/enum/test_enum.py
+++ b/tests/inputs/enum/test_enum.py
@@ -105,7 +105,14 @@ def test_enum_mapped_on_parse():
     assert Test().choice.name == Choice.ZERO.name
 
 
-def test_enum_full_name():
-    assert ArithmeticOperator.NONE.full_name() == "ARITHMETIC_OPERATOR_NONE"
-    assert ArithmeticOperator.PLUS.full_name() == "ARITHMETIC_OPERATOR_PLUS"
-    assert ArithmeticOperator._0_PREFIXED.full_name() == "ARITHMETIC_OPERATOR_0_PREFIXED"
+def test_renamed_enum_members():
+    assert set(ArithmeticOperator.__members__) == {
+        "NONE",
+        "PLUS",
+        "MINUS",
+        "_0_PREFIXED",
+        "ARITHMETIC_OPERATOR_NONE",
+        "ARITHMETIC_OPERATOR_PLUS",
+        "ARITHMETIC_OPERATOR_MINUS",
+        "ARITHMETIC_OPERATOR_0_PREFIXED",
+    }

--- a/tests/inputs/enum/test_enum.py
+++ b/tests/inputs/enum/test_enum.py
@@ -131,6 +131,14 @@ def test_enum_to_json():
     ) == '{"op": "ARITHMETIC_OPERATOR_0_PREFIXED"}'
 
 
+def test_enum_from_json():
+    assert Test().from_json('{}').op == ArithmeticOperator.NONE
+    assert Test().from_json(
+        '{"op": "ARITHMETIC_OPERATOR_PLUS"}').op == ArithmeticOperator.PLUS
+    assert Test().from_json(
+        '{"op": "ARITHMETIC_OPERATOR_0_PREFIXED"}').op == ArithmeticOperator._0_PREFIXED
+
+
 class EnumCompat(betterproto.Enum):
     NONE = 0
     PLUS = 1
@@ -148,3 +156,9 @@ def test_enum_to_json_backwards_compat():
     ) == '{"enum": "PLUS"}'
     assert CompatTest(enum=EnumCompat.MINUS).to_json(
     ) == '{"enum": "MINUS"}'
+
+
+def test_enum_from_json_backwards_compat():
+    assert CompatTest().from_json('{}').enum == EnumCompat.NONE
+    assert CompatTest().from_json('{"enum": "PLUS"}').enum == EnumCompat.PLUS
+    assert CompatTest().from_json('{"enum": "MINUS"}').enum == EnumCompat.MINUS


### PR DESCRIPTION
## Summary

The representation of enums in JSON should not have the prefix removed as implemented in #187.  This PR provides one option for fixing JSON representation of enums.

From the linked [C# docs](https://protobuf.dev/reference/csharp/csharp-generated/#enum) in https://github.com/danielgtaylor/python-betterproto/issues/174 (referenced in the above PR):

> This name transformation does not affect the text used within the JSON representation of messages.

This fix is a somewhat naive approach and I'm open to alternatives. It simply adds in the original enum field in addition to the stripped field.

I looked at an alternative where the JSON would render based on a `full_name` property, however the scope of this started to grow so I figured I'd push up the naive change and start a discussion.

One option would be to replace the value with a tuple of some sort, however it's possible this would create issues with comparisons.

```py
class ArithmeticOperator(betterproto.Enum):
    """
    A "C" like enum with the enum name prefixed onto members, these should be stripped
    """

    NONE = (0, 'ARITHMETIC_OPERATOR_NONE')
    PLUS = (1, 'ARITHMETIC_OPERATOR_PLUS')
    MINUS = (2, 'ARITHMETIC_OPERATOR_MINUS')
    _0_PREFIXED = (3, 'ARITHMETIC_OPERATOR_0_PREFIXED')
```

Another option I thought of was to add an option as to whether to remove the prefix, however I personally would like to have the best of both words - nice python enums along with correct JSON encoding / decoding.

Thoughts?

## Checklist


- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
 
