### PR TITLE
Bump version to 2.0.0b7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Versions suffixed with `b*` are in `beta` and can be installed with `pip install --pre betterproto`.
 
+## [2.0.0b7] - 2024-08-11
+
+- **Breaking**: Support `Pydantic` v2 and dropping support for v1 [#588](https://github.com/danielgtaylor/python-betterproto/pull/588)
+- **Breaking**: The `Message.__getattribute__` method now raises an `AttributeError` when attempting to access an unset `oneof`
+  field. 
+  The previous behavior is accessible via `Message.__unsafe_get` [#510](https://github.com/danielgtaylor/python-betterproto/pull/510).
+  To see how to use the new behavior, refer to [#558](https://github.com/danielgtaylor/python-betterproto/pull/558) 
+  and [README.md](https://github.com/danielgtaylor/python-betterproto#one-of-support).
+
+- Add support for `pickle` methods [#535](https://github.com/danielgtaylor/python-betterproto/pull/535)
+- Add support for `Struct` and `Value` types [#551](https://github.com/danielgtaylor/python-betterproto/pull/551)
+- Add support for `Enum`'s `copy` and `deepcopy` methods [#566](https://github.com/danielgtaylor/python-betterproto/pull/566)
+- Add support for [`Rich` package](https://rich.readthedocs.io/en/latest/index.html) for pretty printing [#508](https://github.com/danielgtaylor/python-betterproto/pull/508)
+- Improve support for streaming messages [#518](https://github.com/danielgtaylor/python-betterproto/pull/518) [#529](https://github.com/danielgtaylor/python-betterproto/pull/529)
+- Improve performance of serializing / de-serializing messages [#545](https://github.com/danielgtaylor/python-betterproto/pull/545)
+- Improve handling of typing collisions. 
+  Refer to [#582](https://github.com/danielgtaylor/python-betterproto/pull/582) 
+  and [README.md](https://github.com/danielgtaylor/python-betterproto#configuration-typing-imports).
+- Fix bugs when converting to / from Python due to `_Timestamp` [#534](https://github.com/danielgtaylor/python-betterproto/pull/534)
+- Fix accessing unset optional fields [#523](https://github.com/danielgtaylor/python-betterproto/pull/523)
+- Fix `Message` equality comparison [#513](https://github.com/danielgtaylor/python-betterproto/pull/513)
+- Fix behavior with long comment messages [#532](https://github.com/danielgtaylor/python-betterproto/pull/532)
+
 ## [2.0.0b6] - 2023-06-25
 
 - **Breaking**: the minimum Python version has been bumped to `3.7` [#444](https://github.com/danielgtaylor/python-betterproto/pull/444)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.0b7] - 2024-08-11
 
 - **Breaking**: Support `Pydantic` v2 and dropping support for v1 [#588](https://github.com/danielgtaylor/python-betterproto/pull/588)
-- **Breaking**: The `Message.__getattribute__` method now raises an `AttributeError` when attempting to access an unset `oneof` 
+- **Breaking**: The attempting to access an unset `oneof` now raises an `AttributeError` 
   field. To see how to access `oneof` fields now, refer to [#558](https://github.com/danielgtaylor/python-betterproto/pull/558) 
   and [README.md](https://github.com/danielgtaylor/python-betterproto#one-of-support).
-- **Breaking**: A custom Enum has been implemented to match the behaviour of being an open set. This has the side effect of
-  preventing any passthrough of Enum members (i.e. Foo.RED.GREEN doesn't work any more)
+- **Breaking**: A custom `Enum` has been implemented to match the behaviour of being an open set. Any checks for `isinstance(enum_member, enum.Enum)` and `issubclass(EnumSubclass, enum.Enum)` will now return `False`. This change also has the side effect of
+  preventing any passthrough of `Enum` members (i.e. `Foo.RED.GREEN` doesn't work any more). See [#293](https://github.com/danielgtaylor/python-betterproto/pull/293) for more info, this fixed many bugs related to `Enum` handling.
 
 - Add support for `pickle` methods [#535](https://github.com/danielgtaylor/python-betterproto/pull/535)
 - Add support for `Struct` and `Value` types [#551](https://github.com/danielgtaylor/python-betterproto/pull/551)
 - Add support for [`Rich` package](https://rich.readthedocs.io/en/latest/index.html) for pretty printing [#508](https://github.com/danielgtaylor/python-betterproto/pull/508)
 - Improve support for streaming messages [#518](https://github.com/danielgtaylor/python-betterproto/pull/518) [#529](https://github.com/danielgtaylor/python-betterproto/pull/529)
 - Improve performance of serializing / de-serializing messages [#545](https://github.com/danielgtaylor/python-betterproto/pull/545)
-- Improve handling of typing collisions. 
+- Improve the handling of message name collisions with typing by allowing the method / type of imports to be configured.
   Refer to [#582](https://github.com/danielgtaylor/python-betterproto/pull/582) 
   and [README.md](https://github.com/danielgtaylor/python-betterproto#configuration-typing-imports).
-- Fix bugs when converting to / from Python due to `_Timestamp` [#534](https://github.com/danielgtaylor/python-betterproto/pull/534)
+- Fix roundtrip parsing of `datetime`s [#534](https://github.com/danielgtaylor/python-betterproto/pull/534)
 - Fix accessing unset optional fields [#523](https://github.com/danielgtaylor/python-betterproto/pull/523)
 - Fix `Message` equality comparison [#513](https://github.com/danielgtaylor/python-betterproto/pull/513)
 - Fix behaviour with long comment messages [#532](https://github.com/danielgtaylor/python-betterproto/pull/532)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix accessing unset optional fields [#523](https://github.com/danielgtaylor/python-betterproto/pull/523)
 - Fix `Message` equality comparison [#513](https://github.com/danielgtaylor/python-betterproto/pull/513)
 - Fix behaviour with long comment messages [#532](https://github.com/danielgtaylor/python-betterproto/pull/532)
+- Add a warning when calling a deprecated message [#596](https://github.com/danielgtaylor/python-betterproto/pull/596)
 
 ## [2.0.0b6] - 2023-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: The `Message.__getattribute__` method now raises an `AttributeError` when attempting to access an unset `oneof` 
   field. To see how to access `oneof` fields now, refer to [#558](https://github.com/danielgtaylor/python-betterproto/pull/558) 
   and [README.md](https://github.com/danielgtaylor/python-betterproto#one-of-support).
-- **Breaking**: A custom Enum has been implemented to match the behaviour of being an open set. This has the side effect
-  prevents any passthrough of Enum members (i.e. Foo.RED.GREEN doesn't work any more)
+- **Breaking**: A custom Enum has been implemented to match the behaviour of being an open set. This has the side effect of
+  preventing any passthrough of Enum members (i.e. Foo.RED.GREEN doesn't work any more)
 
 - Add support for `pickle` methods [#535](https://github.com/danielgtaylor/python-betterproto/pull/535)
 - Add support for `Struct` and `Value` types [#551](https://github.com/danielgtaylor/python-betterproto/pull/551)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.0b7] - 2024-08-11
 
 - **Breaking**: Support `Pydantic` v2 and dropping support for v1 [#588](https://github.com/danielgtaylor/python-betterproto/pull/588)
-- **Breaking**: The `Message.__getattribute__` method now raises an `AttributeError` when attempting to access an unset `oneof`
-  field. 
-  The previous behavior is accessible via `Message.__unsafe_get` [#510](https://github.com/danielgtaylor/python-betterproto/pull/510).
-  To see how to use the new behavior, refer to [#558](https://github.com/danielgtaylor/python-betterproto/pull/558) 
+- **Breaking**: The `Message.__getattribute__` method now raises an `AttributeError` when attempting to access an unset `oneof` 
+  field. To see how to access `oneof` fields now, refer to [#558](https://github.com/danielgtaylor/python-betterproto/pull/558) 
   and [README.md](https://github.com/danielgtaylor/python-betterproto#one-of-support).
+- **Breaking**: A custom Enum has been implemented to match the behaviour of being an open set. This has the side effect
+  prevents any passthrough of Enum members (i.e. Foo.RED.GREEN doesn't work any more)
 
 - Add support for `pickle` methods [#535](https://github.com/danielgtaylor/python-betterproto/pull/535)
 - Add support for `Struct` and `Value` types [#551](https://github.com/danielgtaylor/python-betterproto/pull/551)
-- Add support for `Enum`'s `copy` and `deepcopy` methods [#566](https://github.com/danielgtaylor/python-betterproto/pull/566)
 - Add support for [`Rich` package](https://rich.readthedocs.io/en/latest/index.html) for pretty printing [#508](https://github.com/danielgtaylor/python-betterproto/pull/508)
 - Improve support for streaming messages [#518](https://github.com/danielgtaylor/python-betterproto/pull/518) [#529](https://github.com/danielgtaylor/python-betterproto/pull/529)
 - Improve performance of serializing / de-serializing messages [#545](https://github.com/danielgtaylor/python-betterproto/pull/545)
@@ -28,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bugs when converting to / from Python due to `_Timestamp` [#534](https://github.com/danielgtaylor/python-betterproto/pull/534)
 - Fix accessing unset optional fields [#523](https://github.com/danielgtaylor/python-betterproto/pull/523)
 - Fix `Message` equality comparison [#513](https://github.com/danielgtaylor/python-betterproto/pull/513)
-- Fix behavior with long comment messages [#532](https://github.com/danielgtaylor/python-betterproto/pull/532)
+- Fix behaviour with long comment messages [#532](https://github.com/danielgtaylor/python-betterproto/pull/532)
 
 ## [2.0.0b6] - 2023-06-25
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "betterproto"
-version = "2.0.0b6"
+version = "2.0.0b7"
 description = "A better Protobuf / gRPC generator & library"
 authors = ["Daniel G. Taylor <danielgtaylor@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Bump to v2.0.0b7. I'd really appreciate the great work done to support Pydantic V2 from PR #588 by @gatesn in a new beta release. @Gobot1234 [you said](https://github.com/danielgtaylor/python-betterproto/pull/588#issuecomment-2269525632) you will be able to make a new beta release if I made a PR with a changelog and the bump in the version. So, hopefully this PR captures the changes made since 2.0.0b6 and can be merged.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
 
