### PR TITLE
Fix badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Better Protobuf / gRPC Support for Python
 
-![](https://github.com/danielgtaylor/python-betterproto/workflows/CI/badge.svg)
+![](https://github.com/danielgtaylor/python-betterproto/actions/workflows/ci.yml/badge.svg)
+
 > :octocat: If you're reading this on github, please be aware that it might mention unreleased features! See the latest released README on [pypi](https://pypi.org/project/betterproto/).
 
 This project aims to provide an improved experience when using Protobuf / gRPC in a modern Python environment by making use of modern language features and generating readable, understandable, idiomatic Python code. It will not support legacy features or environments (e.g. Protobuf 2). The following are supported:


### PR DESCRIPTION
## Summary

The badge always shows the build as failing, even if it is actually successful.

This issue has been reported on https://github.com/actions/starter-workflows/issues/1525 , and the fix suggested on https://github.com/actions/starter-workflows/issues/1525#issuecomment-1763431305 works.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
 
