### PR TITLE
Remove error when no fields are set in oneof

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1864,9 +1864,7 @@ class Message(ABC):
                 if getattr(values, field.name, None) is not None
             ]
 
-            if not set_fields:
-                raise ValueError(f"Group {group} has no value; all fields are None")
-            elif len(set_fields) > 1:
+            if len(set_fields) > 1:
                 set_fields_str = ", ".join(set_fields)
                 raise ValueError(
                     f"Group {group} has more than one value; fields {set_fields_str} are not None"


### PR DESCRIPTION
## Summary

Fix https://github.com/danielgtaylor/python-betterproto/issues/604

Methods such as `parse` are often called on a new object: `value = cls().parse(value)`. However, is the message contains oneof fields, this used to make the validator `_validate_field_groups` fail when using pydantic.

I removed the check that at least one value of the `oneof` is defined. This is coherent with gRPC's documentation: "If you have a message with many fields and where _at most_ one field will be set at the same time, you can enforce this behavior and save memory by using the oneof feature." and "You can check which value in a oneof is set _(if any)_ using a special case() or WhichOneof() method"


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
- [X] This PR fixes an issue.
