### PR TITLE
Simplify code: delete py_input_message

### DIFF
--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -756,30 +756,6 @@ class ServiceMethodCompiler(ProtoContentBase):
         return f"/{package_part}{self.parent.proto_name}/{self.proto_name}"
 
     @property
-    def py_input_message(self) -> Optional[MessageCompiler]:
-        """Find the input message object.
-
-        Returns
-        -------
-        Optional[MessageCompiler]
-            Method instance representing the input message.
-            If not input message could be found or there are no
-            input messages, None is returned.
-        """
-        package, name = parse_source_type_name(self.proto_obj.input_type)
-
-        # Nested types are currently flattened without dots.
-        # Todo: keep a fully quantified name in types, that is
-        # comparable with method.input_type
-        for msg in self.request.all_messages:
-            if (
-                msg.py_name == pythonize_class_name(name.replace(".", ""))
-                and msg.output_file.package == package
-            ):
-                return msg
-        return None
-
-    @property
     def py_input_message_type(self) -> str:
         """String representation of the Python type corresponding to the
         input message.

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -70,7 +70,7 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
     {% for method in service.methods %}
     async def {{ method.py_name }}(self
         {%- if not method.client_streaming -%}
-            {%- if method.py_input_message -%}, {{ method.py_input_message_param }}: "{{ method.py_input_message_type }}"{%- endif -%}
+            , {{ method.py_input_message_param }}: "{{ method.py_input_message_type }}"
         {%- else -%}
             {# Client streaming: need a request iterator instead #}
             , {{ method.py_input_message_param }}_iterator: {{ output_file.typing_compiler.union(output_file.typing_compiler.async_iterable(method.py_input_message_type), output_file.typing_compiler.iterable(method.py_input_message_type)) }}
@@ -149,7 +149,7 @@ class {{ service.py_name }}Base(ServiceBase):
     {% for method in service.methods %}
     async def {{ method.py_name }}(self
         {%- if not method.client_streaming -%}
-            {%- if method.py_input_message -%}, {{ method.py_input_message_param }}: "{{ method.py_input_message_type }}"{%- endif -%}
+            , {{ method.py_input_message_param }}: "{{ method.py_input_message_type }}"
         {%- else -%}
             {# Client streaming: need a request iterator instead #}
             , {{ method.py_input_message_param }}_iterator: {{ output_file.typing_compiler.async_iterator(method.py_input_message_type) }}


### PR DESCRIPTION
## Summary

This PR removes the `py_input_message` function from `ServiceMethodCompiler`. This function was only used in two places, in the template file. The return value was not actually used, it was only checked whether it was None or not.

However, the function should never actually return None, since an `rpc` always takes an existing message as parameter. If the function returns None, as far as understand, it means that there is a problem somewhere in betterproto.

In any case, the check is not useful: if the condition that I deleted was not satisfied (which should not happen from what I understand), an invalid code would have been generated since the variable `method.py_input_message_param` would have been used later without having being declared.

I sometimes see things like that in the code, I imagine that it is better that I do small pull-requests each time, what do you think? Or is there any reason to keep the code for now, for example for future use?

## Checklist

- [X] If code changes were made then they have been tested.
