### PR TITLE
Update no-warning tests for pytest-8

### DIFF
--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -35,17 +35,15 @@ def test_message_with_deprecated_field(message):
 
 
 def test_message_with_deprecated_field_not_set(message):
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         Test(value=10)
-
-    assert not record
 
 
 def test_message_with_deprecated_field_not_set_default(message):
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         _ = Test(value=10).message
-
-    assert not record
 
 
 @pytest.mark.asyncio
@@ -58,7 +56,6 @@ async def test_service_with_deprecated_method():
     assert len(record) == 1
     assert str(record[0].message) == f"TestService.deprecated_func is deprecated"
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         await stub.func(Empty())
-
-    assert not record


### PR DESCRIPTION
## Summary

Replace the deprecated `pytest.warns(None)` with the suggested replacement (from https://github.com/pytest-dev/pytest/issues/9404) to make the test suite forward compatible with pytest-8.  This works correctly with pytest-6 as well.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
 
