### PR TITLE
Remove useless method

### DIFF
--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -485,13 +485,6 @@ class FieldCompiler(MessageCompiler):
         return self.proto_obj.proto3_optional
 
     @property
-    def mutable(self) -> bool:
-        """True if the field is a mutable type, otherwise False."""
-        return self.annotation.startswith(
-            ("typing.List[", "typing.Dict[", "dict[", "list[", "Dict[", "List[")
-        )
-
-    @property
     def field_type(self) -> str:
         """String representation of proto field type."""
         return (


### PR DESCRIPTION
## Summary

This small PR removes a useless method. The method was initially defined in https://github.com/danielgtaylor/python-betterproto/commit/b5dcac125024c4579efc9096200a371f67c283f1 

It is no longer used, is not tested, and the implementation probably depends to heavily on the typing compiler to be reliable anyway.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
