### PR TITLE
Fix documentation

### DIFF
--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -661,6 +661,7 @@ class EnumDefinitionCompiler(MessageCompiler):
 
 @dataclass
 class ServiceCompiler(ProtoContentBase):
+    source_file: FileDescriptorProto
     parent: OutputTemplate = PLACEHOLDER
     proto_obj: DescriptorProto = PLACEHOLDER
     path: List[int] = PLACEHOLDER
@@ -682,6 +683,7 @@ class ServiceCompiler(ProtoContentBase):
 
 @dataclass
 class ServiceMethodCompiler(ProtoContentBase):
+    source_file: FileDescriptorProto
     parent: ServiceCompiler
     proto_obj: MethodDescriptorProto
     path: List[int] = PLACEHOLDER

--- a/src/betterproto/plugin/parser.py
+++ b/src/betterproto/plugin/parser.py
@@ -100,9 +100,9 @@ def generate_code(request: CodeGeneratorRequest) -> CodeGeneratorResponse:
             request_data.output_packages[output_package_name].output = False
 
         if "pydantic_dataclasses" in plugin_options:
-            request_data.output_packages[
-                output_package_name
-            ].pydantic_dataclasses = True
+            request_data.output_packages[output_package_name].pydantic_dataclasses = (
+                True
+            )
 
         # Gather any typing generation options.
         typing_opts = [
@@ -114,17 +114,17 @@ def generate_code(request: CodeGeneratorRequest) -> CodeGeneratorResponse:
         # Set the compiler type.
         typing_opt = typing_opts[0] if typing_opts else "direct"
         if typing_opt == "direct":
-            request_data.output_packages[
-                output_package_name
-            ].typing_compiler = DirectImportTypingCompiler()
+            request_data.output_packages[output_package_name].typing_compiler = (
+                DirectImportTypingCompiler()
+            )
         elif typing_opt == "root":
-            request_data.output_packages[
-                output_package_name
-            ].typing_compiler = TypingImportTypingCompiler()
+            request_data.output_packages[output_package_name].typing_compiler = (
+                TypingImportTypingCompiler()
+            )
         elif typing_opt == "310":
-            request_data.output_packages[
-                output_package_name
-            ].typing_compiler = NoTyping310TypingCompiler()
+            request_data.output_packages[output_package_name].typing_compiler = (
+                NoTyping310TypingCompiler()
+            )
 
     # Read Messages and Enums
     # We need to read Messages before Services in so that we can
@@ -249,12 +249,21 @@ def read_protobuf_type(
 
 
 def read_protobuf_service(
-    source_file: FileDescriptorProto, service: ServiceDescriptorProto, index: int, output_package: OutputTemplate
+    source_file: FileDescriptorProto,
+    service: ServiceDescriptorProto,
+    index: int,
+    output_package: OutputTemplate,
 ) -> None:
     service_data = ServiceCompiler(
-        source_file=source_file, parent=output_package, proto_obj=service, path=[6, index]
+        source_file=source_file,
+        parent=output_package,
+        proto_obj=service,
+        path=[6, index],
     )
     for j, method in enumerate(service.method):
         ServiceMethodCompiler(
-            source_file=source_file, parent=service_data, proto_obj=method, path=[6, index, 2, j]
+            source_file=source_file,
+            parent=service_data,
+            proto_obj=method,
+            path=[6, index, 2, j],
         )

--- a/src/betterproto/plugin/parser.py
+++ b/src/betterproto/plugin/parser.py
@@ -100,9 +100,9 @@ def generate_code(request: CodeGeneratorRequest) -> CodeGeneratorResponse:
             request_data.output_packages[output_package_name].output = False
 
         if "pydantic_dataclasses" in plugin_options:
-            request_data.output_packages[output_package_name].pydantic_dataclasses = (
-                True
-            )
+            request_data.output_packages[
+                output_package_name
+            ].pydantic_dataclasses = True
 
         # Gather any typing generation options.
         typing_opts = [
@@ -114,17 +114,17 @@ def generate_code(request: CodeGeneratorRequest) -> CodeGeneratorResponse:
         # Set the compiler type.
         typing_opt = typing_opts[0] if typing_opts else "direct"
         if typing_opt == "direct":
-            request_data.output_packages[output_package_name].typing_compiler = (
-                DirectImportTypingCompiler()
-            )
+            request_data.output_packages[
+                output_package_name
+            ].typing_compiler = DirectImportTypingCompiler()
         elif typing_opt == "root":
-            request_data.output_packages[output_package_name].typing_compiler = (
-                TypingImportTypingCompiler()
-            )
+            request_data.output_packages[
+                output_package_name
+            ].typing_compiler = TypingImportTypingCompiler()
         elif typing_opt == "310":
-            request_data.output_packages[output_package_name].typing_compiler = (
-                NoTyping310TypingCompiler()
-            )
+            request_data.output_packages[
+                output_package_name
+            ].typing_compiler = NoTyping310TypingCompiler()
 
     # Read Messages and Enums
     # We need to read Messages before Services in so that we can

--- a/src/betterproto/plugin/parser.py
+++ b/src/betterproto/plugin/parser.py
@@ -143,7 +143,7 @@ def generate_code(request: CodeGeneratorRequest) -> CodeGeneratorResponse:
     for output_package_name, output_package in request_data.output_packages.items():
         for proto_input_file in output_package.input_files:
             for index, service in enumerate(proto_input_file.service):
-                read_protobuf_service(service, index, output_package)
+                read_protobuf_service(proto_input_file, service, index, output_package)
 
     # Generate output files
     output_paths: Set[pathlib.Path] = set()
@@ -249,12 +249,12 @@ def read_protobuf_type(
 
 
 def read_protobuf_service(
-    service: ServiceDescriptorProto, index: int, output_package: OutputTemplate
+    source_file: FileDescriptorProto, service: ServiceDescriptorProto, index: int, output_package: OutputTemplate
 ) -> None:
     service_data = ServiceCompiler(
-        parent=output_package, proto_obj=service, path=[6, index]
+        source_file=source_file, parent=output_package, proto_obj=service, path=[6, index]
     )
     for j, method in enumerate(service.method):
         ServiceMethodCompiler(
-            parent=service_data, proto_obj=method, path=[6, index, 2, j]
+            source_file=source_file, parent=service_data, proto_obj=method, path=[6, index, 2, j]
         )

--- a/tests/inputs/documentation/documentation.proto
+++ b/tests/inputs/documentation/documentation.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package documentation;
+
+// Documentation of message
+message Test {
+    // Documentation of field
+    uint32 x = 1;
+}
+
+// Documentation of enum
+enum Enum {
+    // Documentation of variant
+    Enum_Variant = 0;
+}
+
+// Documentation of service
+service Service {
+    // Documentation of method
+    rpc get(Test) returns (Test);
+}

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,0 +1,24 @@
+import ast
+import inspect
+
+
+def test_documentation():
+    from .output_betterproto.documentation import Enum, Test, ServiceBase, ServiceStub
+
+    assert Test.__doc__ == "Documentation of message"
+
+    source = inspect.getsource(Test)
+    tree = ast.parse(source)
+    assert tree.body[0].body[2].value.value == "Documentation of field"
+
+    assert Enum.__doc__ == "Documentation of enum"
+
+    source = inspect.getsource(Enum)
+    tree = ast.parse(source)
+    assert tree.body[0].body[2].value.value == "Documentation of variant"
+
+    assert ServiceBase.__doc__ == "Documentation of service"
+    assert ServiceBase.get.__doc__ == "Documentation of method"
+
+    assert ServiceStub.__doc__ == "Documentation of service"
+    assert ServiceStub.get.__doc__ == "Documentation of method"

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -3,7 +3,12 @@ import inspect
 
 
 def test_documentation():
-    from .output_betterproto.documentation import Enum, Test, ServiceBase, ServiceStub
+    from .output_betterproto.documentation import (
+        Enum,
+        ServiceBase,
+        ServiceStub,
+        Test,
+    )
 
     assert Test.__doc__ == "Documentation of message"
 


### PR DESCRIPTION
## Summary

The documentation of services and methods was not properly added to the generated files. The issue was that `ServiceCompiler` and `ServiceMethodCompiler` didn't have access to the value of `source_file`, unlike the other compilers.

As far as I understand, the field was accessed in the `get_comment ` function. Since it was missing, an `AttributeError` was raised, but this error was catched by jinja automatically, as in the following example:

```python
from dataclasses import dataclass

from jinja2 import Template

TEMPLATE: str = """
AA
{{ my_class.field }}
BB
{{ my_class.nothing }}
CC
"""

@dataclass
class MyClass:
    field: int

print(Template(TEMPLATE).render(my_class=MyClass(field=42)))
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
- [X] This PR fixes an issue.