### PR TITLE
Use strict undefined

### DIFF
--- a/src/betterproto/plugin/compiler.py
+++ b/src/betterproto/plugin/compiler.py
@@ -32,6 +32,7 @@ def outputfile_compiler(output_file: OutputTemplate) -> str:
         trim_blocks=True,
         lstrip_blocks=True,
         loader=jinja2.FileSystemLoader(templates_folder),
+        undefined=jinja2.StrictUndefined,
     )
     # Load the body first so we have a compleate list of imports needed.
     body_template = env.get_template("template.py.j2")


### PR DESCRIPTION
## Summary

This prevents jinja from silencing errors occuring in the template file. I mentioned this here: https://github.com/danielgtaylor/python-betterproto/pull/630

At that time, I thought it would be necessary to fix other bugs before it works, but it actually already works.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
