### PR TITLE
Remove useless property

### DIFF
--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -329,12 +329,6 @@ class MessageCompiler(ProtoContentBase):
         return pythonize_class_name(self.proto_name)
 
     @property
-    def annotation(self) -> str:
-        if self.repeated:
-            return self.typing_compiler.list(self.py_name)
-        return self.py_name
-
-    @property
     def deprecated_fields(self) -> Iterator[str]:
         for f in self.fields:
             if f.deprecated:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This small PR (again 🙃 ) removes the `annotation` property of `MessageCompiler`. The function is never called since it is defined correctly in `Fieldcompiler`. Plus, it is wrong anyway.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.