### PR TITLE
Don't repeat tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,17 +4,6 @@ import sys
 import pytest
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--repeat", type=int, default=1, help="repeat the operation multiple times"
-    )
-
-
-@pytest.fixture(scope="session")
-def repeat(request):
-    return request.config.getoption("repeat")
-
-
 @pytest.fixture
 def reset_sys_path():
     original = copy.deepcopy(sys.path)

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -204,8 +204,8 @@ def test_binary_compatibility(test_data: TestData) -> None:
         reference_instance = Parse(sample.json, reference_module().Test())
         reference_binary_output = reference_instance.SerializeToString()
 
-        plugin_instance_from_json: betterproto.Message = (
-            plugin_module.Test().from_json(sample.json)
+        plugin_instance_from_json: betterproto.Message = plugin_module.Test().from_json(
+            sample.json
         )
         plugin_instance_from_binary = plugin_module.Test.FromString(
             reference_binary_output

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -174,22 +174,21 @@ def test_message_equality(test_data: TestData) -> None:
 
 
 @pytest.mark.parametrize("test_data", test_cases.messages_with_json, indirect=True)
-def test_message_json(repeat, test_data: TestData) -> None:
+def test_message_json(test_data: TestData) -> None:
     plugin_module, _, json_data = test_data
 
-    for _ in range(repeat):
-        for sample in json_data:
-            if sample.belongs_to(test_input_config.non_symmetrical_json):
-                continue
+    for sample in json_data:
+        if sample.belongs_to(test_input_config.non_symmetrical_json):
+            continue
 
-            message: betterproto.Message = plugin_module.Test()
+        message: betterproto.Message = plugin_module.Test()
 
-            message.from_json(sample.json)
-            message_json = message.to_json(0)
+        message.from_json(sample.json)
+        message_json = message.to_json(0)
 
-            assert dict_replace_nans(json.loads(message_json)) == dict_replace_nans(
-                json.loads(sample.json)
-            )
+        assert dict_replace_nans(json.loads(message_json)) == dict_replace_nans(
+            json.loads(sample.json)
+        )
 
 
 @pytest.mark.parametrize("test_data", test_cases.services, indirect=True)
@@ -198,28 +197,27 @@ def test_service_can_be_instantiated(test_data: TestData) -> None:
 
 
 @pytest.mark.parametrize("test_data", test_cases.messages_with_json, indirect=True)
-def test_binary_compatibility(repeat, test_data: TestData) -> None:
+def test_binary_compatibility(test_data: TestData) -> None:
     plugin_module, reference_module, json_data = test_data
 
     for sample in json_data:
         reference_instance = Parse(sample.json, reference_module().Test())
         reference_binary_output = reference_instance.SerializeToString()
 
-        for _ in range(repeat):
-            plugin_instance_from_json: betterproto.Message = (
-                plugin_module.Test().from_json(sample.json)
-            )
-            plugin_instance_from_binary = plugin_module.Test.FromString(
-                reference_binary_output
-            )
+        plugin_instance_from_json: betterproto.Message = (
+            plugin_module.Test().from_json(sample.json)
+        )
+        plugin_instance_from_binary = plugin_module.Test.FromString(
+            reference_binary_output
+        )
 
-            # Generally this can't be relied on, but here we are aiming to match the
-            # existing Python implementation and aren't doing anything tricky.
-            # https://developers.google.com/protocol-buffers/docs/encoding#implications
-            assert bytes(plugin_instance_from_json) == reference_binary_output
-            assert bytes(plugin_instance_from_binary) == reference_binary_output
+        # Generally this can't be relied on, but here we are aiming to match the
+        # existing Python implementation and aren't doing anything tricky.
+        # https://developers.google.com/protocol-buffers/docs/encoding#implications
+        assert bytes(plugin_instance_from_json) == reference_binary_output
+        assert bytes(plugin_instance_from_binary) == reference_binary_output
 
-            assert plugin_instance_from_json == plugin_instance_from_binary
-            assert dict_replace_nans(
-                plugin_instance_from_json.to_dict()
-            ) == dict_replace_nans(plugin_instance_from_binary.to_dict())
+        assert plugin_instance_from_json == plugin_instance_from_binary
+        assert dict_replace_nans(
+            plugin_instance_from_json.to_dict()
+        ) == dict_replace_nans(plugin_instance_from_binary.to_dict())


### PR DESCRIPTION
## Summary

`test_inputs.py` used to include some mechanism to repeat tests several times. I don't see any reasons for this since serializing / deserializing messages is deterministic. This option was not used anyway: `repeat` always had a value of 1.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.