### PR TITLE
feat: fix dump one of fields

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -968,9 +968,9 @@ class Message(ABC):
                 field_name=field_name, meta=meta
             )
 
-            if value == self._get_field_default(field_name) and not (
+            if not (
                 selected_in_group or serialize_empty or include_default_value_for_oneof
-            ):
+            ) and value == self._get_field_default(field_name):
                 # Default (zero) values are not serialized. Two exceptions are
                 # if this is the selected oneof item or if we know we have to
                 # serialize an empty message (i.e. zero value was explicitly
@@ -1074,9 +1074,9 @@ class Message(ABC):
                 field_name=field_name, meta=meta
             )
 
-            if value == self._get_field_default(field_name) and not (
+            if not (
                 selected_in_group or serialize_empty or include_default_value_for_oneof
-            ):
+            ) and value == self._get_field_default(field_name):
                 # Default (zero) values are not serialized. Two exceptions are
                 # if this is the selected oneof item or if we know we have to
                 # serialize an empty message (i.e. zero value was explicitly


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Hey 👋 
I generated code with pydantic validation. 
A nested class failed the validation. For some reason, the object is validated twice once with the initialized object and once with empty fields. 

```
    @model_validator(mode="after")
    def check_oneof(cls, values):
        return cls._validate_field_groups(values)
```
Switching the order of the condition made it possible to avoid the second 'extra' validation.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
 
