### PR TITLE
docs: change outdated Slack link to a Discord one

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 There's lots to do, and we're working hard, so any help is welcome!
 
-- :speech_balloon: Join us on [Slack](https://join.slack.com/t/betterproto/shared_invite/zt-f0n0uolx-iN8gBNrkPxtKHTLpG3o1OQ)!
+- :speech_balloon: Join us on [Discord](https://discord.gg/DEVteTupPb)!
 
 What can you do?
 
@@ -20,4 +20,4 @@ What can you do?
         - [Good first issues](https://github.com/danielgtaylor/python-betterproto/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
         - [Issues with tests](https://github.com/danielgtaylor/python-betterproto/issues?q=is%3Aissue+is%3Aopen+label%3A%22has+test%22)
     - New bugfix or idea
-        - If you'd like to discuss your idea first, join us on Slack!
+        - If you'd like to discuss your idea first, join us on Discord!

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
       value: >
         Thanks for taking the time to fill out a bug report!
         
-        If you're not sure it's a bug and you just have a question, the [community Slack channel](https://join.slack.com/t/betterproto/shared_invite/zt-f0n0uolx-iN8gBNrkPxtKHTLpG3o1OQ) is a better place for general questions than a GitHub issue.
+        If you're not sure it's a bug and you just have a question, the [community Discord channel](https://discord.gg/DEVteTupPb) is a better place for general questions than a GitHub issue.
 
   - type: input
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,5 @@ name:
 description:
 contact_links:
   - name: For questions about the library
-    about: Support questions are better answered in our Slack group.
-    url: https://join.slack.com/t/betterproto/shared_invite/zt-f0n0uolx-iN8gBNrkPxtKHTLpG3o1OQ
+    about: Support questions are better answered in our Discord group.
+    url: https://discord.gg/DEVteTupPb

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ value3: str | int = 1
 
 ## Development
 
-- _Join us on [Slack](https://join.slack.com/t/betterproto/shared_invite/zt-f0n0uolx-iN8gBNrkPxtKHTLpG3o1OQ)!_
+- _Join us on [Discord](https://discord.gg/DEVteTupPb)!_
 - _See how you can help &rarr; [Contributing](.github/CONTRIBUTING.md)_
 
 ### Requirements
@@ -575,7 +575,7 @@ protoc \
 
 ## Community
 
-Join us on [Slack](https://join.slack.com/t/betterproto/shared_invite/zt-f0n0uolx-iN8gBNrkPxtKHTLpG3o1OQ)!
+Join us on [Discord](https://discord.gg/DEVteTupPb)!
 
 ## License
 


### PR DESCRIPTION
## Summary

This PR closes #650 by changing all mentions of the Slack channel to a Discord server

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
 
